### PR TITLE
Switch submodule array in init.sh from a static array

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -44,13 +44,12 @@ echo "Local & bblayers conf set for $machine"
 declare -A bsparr
 bsparr+=( ["minnowboard"]="meta-intel" ["raspberrypi2"]="meta-raspberrypi" ["porter"]="meta-renesas" )
 
-declare -a modules=("meta-genivi-dev" "meta-ivi" "poky" "meta-qt5" "meta-openembedded" "meta-rust" "meta-oic" "meta-erlang" "meta-rvi")
-
-if [[ "$machine" != "qemux86-64" ]] ; then
-   bsp=${bsparr[${machine}]}
-   echo "bsp was set to $bsp"
-   modules+=("$bsp")
-fi
+modules=($(git submodule | awk '{ print $2 }'))
+for i in ${bsparr[@]}; do
+   if [[ "$machine" == "qemux86-64" ]] || [[ $i != ${bsparr[${machine}]} ]] ; then
+      modules=(${modules[@]//*$i*})
+   fi
+done
 
 git submodule init "${modules[@]}"
 


### PR DESCRIPTION
The submodule array in init.sh was a hardcoded array, which meant
it would require updating to reflect +- changes to .gitmodules.
This change should lower that maintenance overhead.