### PR TITLE
local.inc: Support only ipk package format

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -2,7 +2,7 @@
 
 DISTRO ?= "poky-ivi-systemd"
 USE_GSTREAMER_1_00 ?= "1"
-PACKAGE_CLASSES ?= "package_rpm package_ipk"
+PACKAGE_CLASSES ?= "package_ipk"
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE ?= "noop"


### PR DESCRIPTION
Remove rpm package format support and only support ipk package format.

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
