### PR TITLE
bblayers.inc: Add developer.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ gdp-src-build/tmp/
 gdp-src-build/logs
 gdp-src-build/tmp-glibc
 gdp-src-build/toaster*
+gdp-src-build/developer.conf

--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -27,3 +27,8 @@ BBLAYERS_NON_REMOVABLE ?= " \
   ${OEROOT}/meta-yocto \
   ${OEROOT}/../meta-ivi/meta-ivi \
   "
+
+# Include local developer settings. This can be used to locally modify the
+# setup of mirrors, caching and any other bitbake variables.
+# The include statement has no effect if the file does not exist.
+include ${TOPDIR}/developer.conf


### PR DESCRIPTION
When developers run "source init.sh [device]", local.conf.[device] file
is copied from templates' to local.conf. So Before running the script,
developers change the local.conf file, the changed line in local.conf
is lost. To prevent this situation, this idea is suggested.
### How to use

Developers can create gdp-local.conf in gdp-src-build directory and
add some changes in gdp-local.conf instead of local.conf.
hen changes are applied in GDP build.

[GDP-227] Improve single branch of genivi-dev-platform

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
