### PR TITLE
Add DragonBoard-410c EULA acceptance to init.sh

### DIFF
--- a/gdp-src-build/conf/templates/dragonboard-410c.local.conf
+++ b/gdp-src-build/conf/templates/dragonboard-410c.local.conf
@@ -1,5 +1,3 @@
 include templates/local.inc
 
 MACHINE = "dragonboard-410c"
-
-ACCEPT_EULA_dragonboard-410c = "1"

--- a/init.sh
+++ b/init.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# Parse target board from arg
+# Parse target board & eula agreement from args
 
 choice=$1
+
+if [[ $2 == "accept-eula" ]] ; then
+   eula=true
+fi
 
 echo "You selected target $choice"
 
@@ -20,12 +24,26 @@ if test -z "$machine" ; then
    printf '%s\n' "${targets[@]}"
    unset machine choice
    return
+else
+   if [[ "$machine" == "dragonboard-410c" ]] && test -z "$eula" ; then
+      echo "Building GDP for DragonBoard 410c requires Qualcomm EULA acceptance."
+      echo "See http://git.yoctoproject.org/cgit/cgit.cgi/meta-qcom/tree/conf/EULA for details."
+      echo "Please rerun init.sh with additional 'accept-eula' argument"
+      unset machine choice
+      return
+   fi
 fi
 
 echo "Generating bitbake configuration files for $machine"
 
 cp gdp-src-build/conf/templates/${machine}.local.conf gdp-src-build/conf/local.conf
 cp gdp-src-build/conf/templates/${machine}.bblayers.conf gdp-src-build/conf/bblayers.conf
+
+# Accept EULA in local.conf
+if [[ $machine == "dragonboard-410c" ]] ; then
+   echo "ACCEPT_EULA_dragonboard-410c = "'"1"'"" >> gdp-src-build/conf/local.conf
+fi
+
 echo "Local & bblayers conf set for $machine"
 
 # init really makes sense only the first time
@@ -54,7 +72,7 @@ git submodule sync "${modules[@]}"
 # is better (because they are not that user friendly otherwise...))
 git submodule update "${modules[@]}"
 
-unset machine choice modules bsp bsparr
+unset machine choice modules bsp bsparr eula
 
 source poky/oe-init-build-env gdp-src-build
 


### PR DESCRIPTION
Require users to pass 'accept-eula' arg when initialising
build environment for dragonboard-410c