### PR TITLE
Update meta renesas and local.conf

### DIFF
--- a/gdp-src-build/conf/templates/porter.local.conf
+++ b/gdp-src-build/conf/templates/porter.local.conf
@@ -1,6 +1,3 @@
 include templates/renesas.local.inc
 
 MACHINE = "porter"
-
-# Setting for u-boot Wayland
-UBOOT_MACHINE = "porter_vin_config"

--- a/gdp-src-build/conf/templates/silk.local.conf
+++ b/gdp-src-build/conf/templates/silk.local.conf
@@ -1,6 +1,3 @@
 include templates/renesas.local.inc
 
 MACHINE = "silk"
-
-# Setting for u-boot Wayland
-UBOOT_MACHINE = "silk_vin_config"


### PR DESCRIPTION
Update to the current upstream Renesas R-Car Gen 2 meta-renesas. Also simplify the Porter and Silk board local.conf thanks to changes introduced in meta-renesas. See commit messages for details.

Confirmed to work with the Porter board with the following build config (the GDP SHA before G11):
Build Configuration:
BB_VERSION        = "1.28.0"
BUILD_SYS         = "x86_64-linux"
NATIVELSBSTRING   = "Ubuntu-14.04"
TARGET_SYS        = "arm-poky-linux-gnueabi"
MACHINE           = "porter"
DISTRO            = "poky-ivi-systemd"
DISTRO_VERSION    = "10.0.1"
TUNE_FEATURES     = "arm armv7a vfp neon callconvention-hard cortexa15"
TARGET_FPU        = "vfp-neon"
meta              
meta-yocto        
meta-yocto-bsp    = "HEAD:fc45deac89ef63ca1c44e763c38ced7dfd72cbe1"
meta-ivi          
meta-ivi-bsp      = "HEAD:43ac797bda5dd72ad89771fc95e25296fc8b8b61"
meta-oe           
meta-filesystems  
meta-ruby         = "HEAD:ad6133a2e95f4b83b6b3ea413598e2cd5fb3fd90"
meta-qt5          = "HEAD:ea37a0bc987aa9484937ad68f762b4657c198617"
meta-genivi-dev   = "HEAD:88aaaea7318ba1c4c4dda494af847c868b392760"
meta-rust         = "HEAD:f13ac9d48ae928b761d7be204fa8f877d41e7099"
meta-oic          = "HEAD:69146eaf8bc05c74c377e731b7e16d82854a4659"
meta-erlang       = "HEAD:4d7eacc8e6593934ed5b0c8abc3d3e9dc339d849"
meta-rvi          = "HEAD:de9d548fe35e2cee8688faaae910b4f6f7fea17e"
meta-renesas      
meta-rcar-gen2    = "genivi-10-bsp-1.10.0:98e3453096c4c38fc4819be6888c83d43903383d"
meta-multimedia   = "HEAD:ad6133a2e95f4b83b6b3ea413598e2cd5fb3fd90"