### PR TITLE
meta-ivi: git repo fix for dlt-daemon + node-startup-controller

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = http://github.com/genivi/meta-genivi-dev.git
 [submodule "meta-ivi"]
 	path = meta-ivi
-	url = http://git.yoctoproject.org/git/meta-ivi
+	url = http://github.com/GENIVI/meta-ivi.git
 [submodule "meta-qt5"]
 	path = meta-qt5
 	url = git://github.com/meta-qt5/meta-qt5.git


### PR DESCRIPTION
meta-ivi 9.0 branch has been updated to hotfix issues fetching
upstream dlt-daemon + node-startup-controller refs. Also switch
submodule to github.