### PR TITLE
Add raspberrypi3 to supported targets, including fix to bluetooth

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -11,7 +11,7 @@ fi
 echo "You selected target $choice"
 
 declare -a targets=("qemux86-64" "porter" "raspberrypi2" "raspberrypi3" "minnowboard" "silk" "dragonboard-410c")
-declare -a supported=("qemux86-64" "minnowboard" "raspberrypi2" "dragonboard-410c")
+declare -a supported=("qemux86-64" "minnowboard" "raspberrypi2" "raspberrypi3" "dragonboard-410c")
 declare -a variables=("choice" "eula" "machine" "modules" "bsp" "bsparr" "supported" "targets" "variables")
 
 for i in ${targets[@]}; do


### PR DESCRIPTION
meta-genivi-dev:
4f0a080 - rpi-config: Fix bluetooth launch issue in rpi3