### PR TITLE
renesas: add renesas r-car gen 2 support for GDP11

### DIFF
--- a/gdp-src-build/conf/templates/porter.local.conf
+++ b/gdp-src-build/conf/templates/porter.local.conf
@@ -1,6 +1,3 @@
 include templates/renesas.local.inc
 
 MACHINE = "porter"
-
-# Setting for u-boot Wayland
-UBOOT_MACHINE = "porter_vin_config"

--- a/gdp-src-build/conf/templates/renesas.local.inc
+++ b/gdp-src-build/conf/templates/renesas.local.inc
@@ -7,9 +7,7 @@ BB_MULTIMEDIA_KERNEL_MODULE = "fdpm-kernel-module|mmngr-kernel-module|\
 BB_MULTIMEDIA_USER_MODULE = "fdpm-user-module|mmngr-user-module|\
                              mmngrbuf-user-module|omx-user-module|\
 							 s3ctl-user-module|vspm-user-module|libmemcpy"
-BB_MULTIMEDIA_TEST_MODULE = "fdpm-tp-user-module|mmngr-tp-user-module|\
-                             mmngrbuf-tp-user-module|s3ctl-tp-user-module|\
-							 vspm-tp-user-module"
+BB_MULTIMEDIA_TEST_MODULE = "fdpm-tp-user-module|mmngr-tp-user-module|mmngrbuf-tp-user-module|s3ctl-tp-user-module|vspm-tp-user-module"
 BB_GST_PLUGINS = "meta-renesas/meta-rcar-gen2/recipes-multimedia/gstreamer"
 MULTIMEDIA_BB = "${BB_MULTIMEDIA_KERNEL_MODULE}|${BB_MULTIMEDIA_USER_MODULE}|\
                  ${BB_MULTIMEDIA_TEST_MODULE}|${BB_GST_PLUGINS}"

--- a/gdp-src-build/conf/templates/silk.local.conf
+++ b/gdp-src-build/conf/templates/silk.local.conf
@@ -1,6 +1,3 @@
 include templates/renesas.local.inc
 
 MACHINE = "silk"
-
-# Setting for u-boot Wayland
-UBOOT_MACHINE = "silk_vin_config"

--- a/init.sh
+++ b/init.sh
@@ -11,7 +11,7 @@ fi
 echo "You selected target $choice"
 
 declare -a targets=("qemux86-64" "porter" "raspberrypi2" "raspberrypi3" "minnowboard" "silk" "dragonboard-410c")
-declare -a supported=("qemux86-64" "minnowboard" "raspberrypi2" "raspberrypi3" "dragonboard-410c")
+declare -a supported=("qemux86-64" "porter" "minnowboard" "raspberrypi2" "raspberrypi3" "dragonboard-410c" "silk")
 declare -a variables=("choice" "eula" "machine" "modules" "bsp" "bsparr" "supported" "targets" "variables")
 
 for i in ${targets[@]}; do


### PR DESCRIPTION
Upgrade to meta-renesas YP 2.1 release.
Enable porter/silk board support for GDP Master
branch in init.sh again.