### PR TITLE
Add error message if mistakingly sourced from non bash (e.g zsh)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Note that this script is supposed to be sourced
+if [ ! -n "$BASH" ]
+then
+echo GDP and Yocto in general only works with bash as the interactive shell.
+echo Please retry with bash
+return
+fi
 
 # Parse target board & eula agreement from args
 


### PR DESCRIPTION
zsh will give cryptic error message

    init.sh:13: unknown file attribute

better make a good error message if developer forgot to switch shell.
