### PR TITLE
Add toaster files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gdp-src-build/sstate-cache
 gdp-src-build/tmp/
 gdp-src-build/logs
 gdp-src-build/tmp-glibc
+gdp-src-build/toaster*


### PR DESCRIPTION
[GDP-449] toaster files are currently reported as untracked.
This change rectifies that problem.