### PR TITLE
meta-rust: Update meta-rust

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = git://git.yoctoproject.org/poky
 [submodule "meta-rust"]
 	path = meta-rust
-	url = git://github.com/jmesmon/meta-rust.git
+	url = git://github.com/meta-rust/meta-rust.git
 [submodule "meta-oic"]
 	path = meta-oic
 	url = http://git.yoctoproject.org/git/meta-oic.git


### PR DESCRIPTION
New version of meta-rust is required for building
RVI SOTA Client.

[GDP-517] rvi-sota-client-git-r0 compiling failed

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>