### PR TITLE
meta-iot-web: Add new layer for iotivity-node support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "meta-qcom"]
     path = meta-qcom
     url = git://git.yoctoproject.org/meta-qcom
+[submodule "meta-iot-web"]
+	path = meta-iot-web
+	url = https://github.com/ostroproject/meta-iot-web


### PR DESCRIPTION
IoTivity NodeJS bindings ease development of IoT projects.
For more tips and details about using this, please check:
https://wiki.iotivity.org/automotive .

Current version is supporting IoTivity 1.2.0 from meta-oic.

[GDP-160] meta-genivi-ocf-demo merging

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>