### PR TITLE
chromium: Add meta-browser submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "meta-qcom"]
     path = meta-qcom
     url = git://git.yoctoproject.org/meta-qcom
+[submodule "meta-browser"]
+	path = meta-browser
+	url = git://github.com/OSSystems/meta-browser.git

--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -14,12 +14,14 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
   ${TOPDIR}/../meta-openembedded/meta-ruby \
+  ${TOPDIR}/../meta-openembedded/meta-gnome \
   ${TOPDIR}/../meta-qt5 \
   ${TOPDIR}/../meta-genivi-dev/meta-genivi-dev \
   ${TOPDIR}/../meta-rust \
   ${TOPDIR}/../meta-oic \
   ${TOPDIR}/../meta-erlang \
   ${TOPDIR}/../meta-rvi \
+  ${TOPDIR}/../meta-browser \
   "
 
 BBLAYERS_NON_REMOVABLE ?= " \


### PR DESCRIPTION
Add the meta-browser layer as a submodule, and add it to bblayers.conf together with meta-gnome, which is required because of chromium dependencies.

These changes need to be combined with this PR for meta-genivi-dev: GENIVI/meta-genivi-dev#53

Chromium would not be built by default yet, this is required to add it to the image:
```
IMAGE_INSTALL_append = " chromium-wayland"