### PR TITLE
Drop Faytech support

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -10,9 +10,6 @@ LICENSE_FLAGS_WHITELIST  += "commercial"
 
 #INCOMPATIBLE_LICENSE ?= "GPLv3"
 
-# Flag for Faytech Touch Monitor support, '1' will enable kernel driver patch
-#USE_FAYTECH_MONITOR = "1"
-
 PREFERRED_VERSION_audiomanager ?= "7.0"
 PREFERRED_VERSION_audiomanagerplugins ?= "7.0"
 


### PR DESCRIPTION
[GDP-546] Drop Faytech support

Dropping Faytech monitor support since they've been known to cause
various problems and therefore make maintenance hard. List of currently
supported peripherals can be found at:
https://at.projects.genivi.org/wiki/display/GDP/GDP+and+peripherals

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>