### PR TITLE
meta-iot-web: Support aarch64 & switch repo URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	branch = 1.0.1
 [submodule "meta-iot-web"]
 	path = meta-iot-web
-	url = https://github.com/ostroproject/meta-iot-web
+	url = https://github.com/genivi/meta-iot-web
 [submodule "meta-rvi"]
 	path = meta-rvi
 	url = git://github.com/GENIVI/meta-rvi.git


### PR DESCRIPTION
We temporarily switch meta-iot-web URL to the github.com/genivi aiming
to switch back as soon as the aarch64 fix is included

dc4ccf2 Support aarch64 targets by passing arm64 to npm

[GDP-571] Iotivity build failure on Dragonboard

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>