### PR TITLE
git-submodule-bump: Add no-merges option

### DIFF
--- a/git-submodule-bump
+++ b/git-submodule-bump
@@ -27,6 +27,6 @@ OLDCOMMIT=$(git diff ${SUBMODULE}|grep "^-Subproject"|cut -d' ' -f3)
 
 MSG=$(echo "${SUBMODULE}: ${SHORTLOG}")
 MSG+=$'\n\n'
-MSG+=$(git -C ${SUBMODULE} log --format="%h %s" ${OLDCOMMIT}..${NEWCOMMIT})
+MSG+=$(git -C ${SUBMODULE} log --no-merges --format="%h %s" ${OLDCOMMIT}..${NEWCOMMIT})
 
 git commit -s -m "${MSG}" "${SUBMODULE}"


### PR DESCRIPTION
The merge commit deteriorates readability in commit log.
So remove merge commit when the commit log is created by
git-submodule-bump.

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>