### PR TITLE
readme: add Renesas R-Car (Gen 3) M3 Starter Kit board

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ To initiate the build environment:
 
     source init.sh $target
 
-The current supported targets are qemux86-64, porter, raspberrypi2, raspberrypi3, minnowboard, silk.
+The current supported targets are qemux86-64, porter, raspberrypi2, raspberrypi3,
+minnowboard, silk and r-car-m3-starter-kit.
 Currently this requires the use of the bash shell
 
 The `init.sh` script handles the the `$target` specific bitbake configuration.


### PR DESCRIPTION
As requested by @gunnarx I have gone ahead and created this PR to add the recently merged Renesas R-Car (Gen 3) M3 Starter Kit board to the readme. meta-genivi-dev PR #75 does the same for that layer. I have not added a m-g-d SHA update to this commit to make it easier to merge.