### PR TITLE
git-submodule-bump: Change exit number

### DIFF
--- a/git-submodule-bump
+++ b/git-submodule-bump
@@ -12,13 +12,13 @@ SHORTLOG=${1}
 if test -z "${SHORTLOG}"; then
     echo -e "Usage:\n"
     echo "${0} COMMIT_SUMMARY"
-    exit -1
+    exit 1
 fi
 
 CHANGED_MOD=$(git submodule status | grep '^+' | tr -d + | head -n 1)
 if test -z "${CHANGED_MOD}"; then
     echo "No module updated."
-    exit -2
+    exit 2
 fi
 
 SUBMODULE=$(echo ${CHANGED_MOD} | cut -d' ' -f2)


### PR DESCRIPTION
In shell script, exit status should be between 0 and 255.
0 is success number and others are failure number.

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>