### PR TITLE
Fix JIRA GDP-583 with R-Car M3 Starter Kit build using click-through gfx/mmp pkgs on Go.CD

### DIFF
--- a/gdp-src-build/conf/templates/r-car-m3-starter-kit.local.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-starter-kit.local.conf
@@ -1,8 +1,15 @@
 # Include general conf for Renesas R-Car Gen 3 boards
 include templates/renesas-rcar-gen3.local.inc
 
+# Renesas gfx/mmp package control:
+# 1) For the Evaluation (click-through licensed) gfx/mmp packages
+#    'use_eva_pkg' must be added to DISTRO_FEATURES.
+# 2) If you are using the full version of those packages then
+#    comment out this line as it is not needed.
+DISTRO_FEATURES_append = " use_eva_pkg"
+
 # Select the M3 SoC
 SOC_FAMILY = "r8a7796"
 
 # Select the M3 Starter Kit board
-MACHINE ?= "m3ulcb"
+MACHINE = "m3ulcb"


### PR DESCRIPTION
Typically the Renesas click-through licensed Evaluation
gfx and mmp packages will be used with the R-Car Gen 3
Starter Kit boards. Doing so requires a modification
to the DISTRO_FEATURES. Make that change the default
in the local.conf template for the board.

Fixes Jira issue GDP-583.

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>