### PR TITLE
Remove Bashisms and improve git-submodule-bump

### DIFF
--- a/git-submodule-bump
+++ b/git-submodule-bump
@@ -10,8 +10,7 @@
 
 SHORTLOG=${1}
 if test -z "${SHORTLOG}"; then
-    echo -e "Usage:\n"
-    echo "${0} COMMIT_SUMMARY"
+    echo "Usage: ${0} <commit summary>"
     exit 1
 fi
 
@@ -25,8 +24,9 @@ SUBMODULE=$(echo ${CHANGED_MOD} | cut -d' ' -f2)
 NEWCOMMIT=$(echo ${CHANGED_MOD} | cut -d' ' -f1)
 OLDCOMMIT=$(git diff ${SUBMODULE}|grep "^-Subproject"|cut -d' ' -f3)
 
-MSG=$(echo "${SUBMODULE}: ${SHORTLOG}")
-MSG+=$'\n\n'
-MSG+=$(git -C ${SUBMODULE} log --no-merges --format="%h %s" ${OLDCOMMIT}..${NEWCOMMIT})
+MSG="${SUBMODULE}: ${SHORTLOG}
+
+$(git -C ${SUBMODULE} log --no-merges --format="%h %s" ${OLDCOMMIT}..${NEWCOMMIT})
+"
 
 git commit -s -m "${MSG}" "${SUBMODULE}"

--- a/git-submodule-bump
+++ b/git-submodule-bump
@@ -8,7 +8,7 @@
 #
 # Author: Zeeshan Ali <zeeshan.ali@pelagicore.com>
 
-SHORTLOG=${1}
+SHORTLOG="$*"
 if test -z "${SHORTLOG}"; then
     echo "Usage: ${0} <commit summary>"
     exit 1
@@ -29,4 +29,4 @@ MSG="${SUBMODULE}: ${SHORTLOG}
 $(git -C ${SUBMODULE} log --no-merges --format="%h %s" ${OLDCOMMIT}..${NEWCOMMIT})
 "
 
-git commit -s -m "${MSG}" "${SUBMODULE}"
+git commit -s -e -m "${MSG}" "${SUBMODULE}"


### PR DESCRIPTION
Partial improvement of git-submodule-bump and fix bug [GDP-638](https://at.projects.genivi.org/jira/browse/GDP-638).   Ultimately I'd like to give the changed submodule as argument, but not the time for fixing this now.