### PR TITLE
Chromium multi-seat implementation

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -28,7 +28,7 @@ COMPATIBLE_MACHINE_armv7ve = "(.*)"
 
 # Renesas workarounds
 
-COMPATIBLE_MACHINE_m3ulcb = "(.*)"
+COMPATIBLE_MACHINE_rcar-gen3 = "(.*)"
 
 # Apply same TUNE_FEATURES as in an armv7a build
 ARMFPABI_armv7ve = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'arm_float_abi=hard', 'arm_float_abi=softfp', d)}"

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -35,3 +35,13 @@ ARMFPABI_armv7ve = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard',
 
 # Remove cortexa7 optimization that conflicts with Chromium's hardcoded ARM flags
 TUNE_FEATURES_remove_armv7ve = "cortexa7"
+
+# Multi-seat implementation
+
+SRC_URI_remove = " git://github.com/01org/ozone-wayland.git;destsuffix=${OZONE_WAYLAND_GIT_DESTSUFFIX};branch=${OZONE_WAYLAND_GIT_B\
+RANCH};rev=${OZONE_WAYLAND_GIT_SRCREV} file://chromium-wayland/0006-Remove-GBM-support-from-wayland.gyp.patch"
+
+OZONE_WAYLAND_GIT_FORK   = "git://github.com/jaragunde/ozone-wayland.git"
+OZONE_WAYLAND_GIT_BRANCH = "wip/multi-seat"
+OZONE_WAYLAND_GIT_SRCREV = "3af3d4eee5f48a420e90fae6de54594ec31d27d6"
+SRC_URI_append = " ${OZONE_WAYLAND_GIT_FORK};destsuffix=${OZONE_WAYLAND_GIT_DESTSUFFIX};branch=${OZONE_WAYLAND_GIT_BRANCH};rev=${OZONE_WAYLAND_GIT_SRCREV}"

--- a/meta-genivi-dev/meta-genivi-dev/recipes-graphics/wayland/wayland-ivi-extension/0001-ilmControl-fix-memory-corruption-at-input-listener.patch
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-graphics/wayland/wayland-ivi-extension/0001-ilmControl-fix-memory-corruption-at-input-listener.patch
@@ -1,0 +1,29 @@
+From b933a950ff8415217cbd29a4b0d89eace17c8cff Mon Sep 17 00:00:00 2001
+From: Emre Ucan <eucan@de.adit-jv.com>
+Date: Wed, 19 Apr 2017 10:23:16 +0200
+Subject: [PATCH] ilmControl: fix memory corruption at input listener
+
+Allocate memory in the size of accepted_seat struct instead of
+size of a pointer of the struct
+
+Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>
+---
+ ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+index 0664016..5b4ad45 100644
+--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
++++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+@@ -934,7 +934,7 @@ input_listener_input_acceptance(void *data,
+         return;
+     }
+ 
+-    accepted_seat = calloc(1, sizeof(accepted_seat));
++    accepted_seat = calloc(1, sizeof(*accepted_seat));
+     if (accepted_seat == NULL) {
+         fprintf(stderr, "Failed to allocate memory for accepted seat\n");
+         return;
+-- 
+2.1.4
+

--- a/meta-genivi-dev/meta-genivi-dev/recipes-graphics/wayland/wayland-ivi-extension_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-graphics/wayland/wayland-ivi-extension_%.bbappend
@@ -6,6 +6,7 @@ FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = "\
     file://EGLWLInputEventExample.service \
     file://EGLWLMockNavigation.service \
+    file://0001-ilmControl-fix-memory-corruption-at-input-listener.patch \
     "
 
 FILES_${PN} += "\


### PR DESCRIPTION
This patch set adds the multi-seat implementation to the chromium build in GENIVI.

The multi-seat patch has already been modified to pull the ozone-wayland fork that implements [multi-seat](https://github.com/jaragunde/ozone-wayland/tree/wip/multi-seat).

Unfortunately, we must wait to merge this PR. It includes a downstream patch for wayland-ivi-extension to fix GDP-616. The patch must be modified when a new bugfix release of that software happens.