### PR TITLE
pulseaudio: Load modules w/ a2dp protocol support

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/pulseaudio/pulseaudio/am_poc.pa
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/pulseaudio/pulseaudio/am_poc.pa
@@ -60,3 +60,8 @@ set-default-sink null
 # Make the specified source (identified by its symbolic name) the default source.
 set-default-source null-monitor
 
+# Used o support sound over bluetooth
+load-module module-bluetooth-discover headset=auto
+load-module module-switch-on-connect
+load-module module-bluetooth-policy a2dp_source=1
+


### PR DESCRIPTION
Add load module lines to the configuration for pulseaudio that enables
the a2dp protocol.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>