### PR TITLE
[GDP-581] init.sh: Return 1 when provided unsupported target

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -132,4 +132,6 @@ if setupGitSubmodules $1 $2 $3 ; then
     source poky/oe-init-build-env gdp-src-build
     echo
     echo "Now run:  bitbake genivi-dev-platform"
+else
+    return 1
 fi


### PR DESCRIPTION
Make the init.sh script return non-zero when an unsupported target is
given as argument. This fixes bug GDP-581.

[GDP-581] init.sh has successful return code even for unknown target

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>