### PR TITLE
local.conf: Apply compilation hardening for GDP

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -33,3 +33,13 @@ BB_DISKMON_DIRS = "\
 # track the version of this file when it was generated. This can safely be ignored if
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
+
+require conf/distro/include/security_flags.inc
+
+# Fixme: these pkgs are bronken while enable security_flags
+SECURITY_CFLAGS_pn-dbus-c++ = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-lttng-ust = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-python-uinput = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-python-storm = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-persistence-administrator = ""
+SECURITY_LDFLAGS_pn-persistence-administrator = ""


### PR DESCRIPTION
Add extra security compile options to CFLAGS and LDFLAGS.
Some packages are in blacklist:
	+ dbus-c++ (no -pie -fpie flags)
	+ lttng-ust (no -pie -fpie flags)
	+ python-uinput (no -pie -fpie flags)
	+ python-storm (no -pie -fpie flags)
	+ persistence-administrator (no apply any options)

Build and tested only on QEMU x86-64

more details:
http://www.yoctoproject.org/docs/2.3/mega-manual/mega-manual.html#security-flags

Signed-off-by: Phong Tran <tranmanphong@gmail.com>