### PR TITLE
Better source archive (ci-build script)

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -123,6 +123,12 @@ stop_if_failure
 # The values can be overridden by defining environment variables
 # If no value given, use this default:
 define_with_default BUILD_SDK false
+define_with_default RELEASE_BUILD true
+if [ $RELEASE_BUILD == true ] ; then
+  define_with_default SOURCE_ARCHIVE true
+else
+  define_with_default SOURCE_ARCHIVE false
+fi
 define_with_default RM_WORK false
 define_with_default REUSE_STANDARD_DL_DIR true
 define_with_default REUSE_STANDARD_SSTATE_DIR true
@@ -253,6 +259,16 @@ fi
 # LOCAL CONF MODIFICATIONS
 if [[ "$RM_WORK" == "true" ]]; then
   append_local_conf 'INHERIT += "rm_work"'
+fi
+
+if [[ "$SOURCE_ARCHIVE" == "true" ]]; then
+  append_local_conf 'INHERIT += "archiver"'
+fi
+
+if [[ "$RELEASE_BUILD" == "true" ]]; then
+  append_local_conf 'COPY_LIC_MANIFEST = "1"'
+  append_local_conf 'COPY_LIC_DIRS = "1"'
+  append_local_conf 'LICENSE_CREATE_PACKAGE = "1"'
 fi
 
 if [[ -n "$DL_DIR" ]]; then


### PR DESCRIPTION
Let the ci build script do the settings for source and license info instead of pipelines

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>
