### PR TITLE
Create a file list for the image (ci-build script)

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -284,11 +284,14 @@ if [[ "$BUILD_SDK" == "true" ]]; then
   bitbake meta-ide-support
 fi
 
+cd "$BASEDIR"
 rm -f logs.tar logs.tar.gz
 find gdp-src-build/tmp/work \( -name "*.log" -o -name "log.*" -o -name "run.*" \) -print0 | xargs -0 tar uf logs.tar || true
 gzip logs.tar || true
 
-cd "$BASEDIR"
+# Soften up the failure requirements here.  Maybe sometimes
+# some things can't be staged, which is probably ok.
+set +e
 rm -rf staging
 shopt -s nullglob
 stage_artifact mv gdp-src-build/tmp/deploy/licenses
@@ -300,6 +303,7 @@ stage_artifact mv logs.tar.gz
 stage_artifact cp gdp-src-build/buildhistory/images/*/glibc/genivi-dev-platform/files-in-image.txt
 stage_artifact mv gdp-src-build/buildhistory
 stage_artifact mv gdp-src-build/tmp/buildstats
+set -e
 
 # Environment contains alot of variables from Go.CD that specify the built
 # version/hash, and other metadata.  Let's store them for future reference.

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -296,7 +296,10 @@ stage_artifact mv gdp-src-build/tmp/deploy/licenses/genivi-dev-platform*/license
 stage_artifact mv gdp-src-build/tmp/deploy/sdk*
 stage_artifact cp gdp-src-build/tmp/deploy/images/*
 stage_artifact cp gdp-src-build/conf/*.conf
-stage_artifact cp logs.tar.gz
+stage_artifact mv logs.tar.gz
+stage_artifact cp gdp-src-build/buildhistory/images/*/glibc/genivi-dev-platform/files-in-image.txt
+stage_artifact mv gdp-src-build/buildhistory
+stage_artifact mv gdp-src-build/tmp/buildstats
 
 # Environment contains alot of variables from Go.CD that specify the built
 # version/hash, and other metadata.  Let's store them for future reference.


### PR DESCRIPTION
    ci-build.sh: Create a file list for the image
    
    For some situations it's useful to just quickly confirm if a file exists
    in the system. If publishing a small text file containing a file
    manifest then there's no need to download a large image or tarball to do
    such checks.
    
    ci-build.sh will now do that by default and it's possible to turn off
    by env var CREATE_ROOTFS_FILE_LIST = false
    
    Note: It was simply written for .tar.gz rootfs packages now - so this
    might need tweaking if we don't include a tarball in IMAGE_FSTYPES in
    some cases.
    
    Signed-off-by: Gunnar Andersson <gandersson@genivi.org>
