### PR TITLE
Compile chromium for Dragonboard

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/dragonboard-410c/include.gypi
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/dragonboard-410c/include.gypi
@@ -1,0 +1,6 @@
+{
+  'variables': {
+    # Configure for armv8 compilation
+    'target_arch': 'arm64',
+  },
+}

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/dragonboard-410c/oe-defaults.gypi
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/dragonboard-410c/oe-defaults.gypi
@@ -1,0 +1,15 @@
+{
+  'variables': {
+    'use_system_bzip2': 1,
+    'disable_nacl': 1,
+    'proprietary_codecs': 1,
+    'v8_use_snapshot': 1,
+    'use_system_ffmpeg': 0,
+    'linux_use_tcmalloc': 0,
+    'linux_link_kerberos': 0,
+    'use_kerberos': 0,
+    'use_cups': 0,
+    'use_gnome_keyring': 0,
+    'linux_link_gnome_keyring': 0
+  },
+}

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -30,6 +30,10 @@ COMPATIBLE_MACHINE_armv7ve = "(.*)"
 
 COMPATIBLE_MACHINE_rcar-gen3 = "(.*)"
 
+# Try other armv8 / 64 bit, like Dragonboard
+COMPATIBLE_MACHINE_dragonboard-410c = "(.*)"
+
+
 # Apply same TUNE_FEATURES as in an armv7a build
 ARMFPABI_armv7ve = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'arm_float_abi=hard', 'arm_float_abi=softfp', d)}"
 


### PR DESCRIPTION
Just out of interest, modified the compatible machine and inserted the same gypi file as R-Car to make this compile. It seems to compile OK but is completely untested.  This PR is not intended to be merged right away but mostly to get it into some kind of testing/evaluation/further work queue.
