### PR TITLE
Set keyboard layout to default (English)

### DIFF
--- a/meta-genivi-dev/poky/meta/recipes-graphics/wayland/weston/weston.ini
+++ b/meta-genivi-dev/poky/meta/recipes-graphics/wayland/weston/weston.ini
@@ -7,8 +7,5 @@ ivi-input-module=ivi-input-controller.so
 transition-duration=300
 cursor-theme=default
 
-[keyboard]
-keymap_layout=de
-
 [input-method]
 path=


### PR DESCRIPTION
The keyboard layout is set to German in weston.ini. This change removes
that setting making weston load the default layout i.e. English.

[GDP-574] GDP has German keyboard layout

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>