### PR TITLE
weston-service: Restart on crash

### DIFF
--- a/meta-genivi-dev/poky/meta/recipes-graphics/wayland/weston/weston.service
+++ b/meta-genivi-dev/poky/meta/recipes-graphics/wayland/weston/weston.service
@@ -6,6 +6,8 @@ After=dbus.service rc.pvr.service
 ExecStart=/usr/bin/weston-launch -u root -- --idle-time=4294967
 ExecStop=/usr/bin/killall -s KILL weston
 Type=simple
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a workaround to solve the issue with weston-launch some times
failing to start.

[GDP-607] Sometimes Weston 1.11 fails to start

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>