### PR TITLE
Integrate Cannelloni with the Yocto build system

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-dev.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-dev.bb
@@ -16,4 +16,5 @@ ALLOW_EMPTY_${PN} = "1"
 RDEPENDS_${PN} += "\
     openssh-sftp-server \
     connman-client \
+    cannelloni \
     "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/cannelloni.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/cannelloni.bb
@@ -1,0 +1,39 @@
+SUMMARY = "SocketCAN over Ethernet tunnel using UDP to transfer CAN frames between two machines"
+SECTION = "console/network"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPLv2;md5=B234EE4D69F5FCE4486A80FDAF4A4263"
+PR = "r0"
+
+DEPENDS = " \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
+          "
+
+SRC_URI = "git://github.com/mguentner/cannelloni \
+           file://launch_cannelloni.sh \
+           file://launch_cannelloni.service "
+SRCREV = "0fb6880b719b8acf2b4210b264b7140135e4be8a"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
+
+inherit pkgconfig cmake
+
+inherit systemd
+
+SYSTEMD_SERVICE_${PN} = "launch_cannelloni.service"
+INITSCRIPT_NAME = "launch_cannelloni.sh"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 cannelloni ${D}${bindir}
+
+    install -m 0755 ${WORKDIR}/launch_cannelloni.sh ${D}${bindir}
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/launch_cannelloni.service ${D}${systemd_unitdir}/system
+}
+
+RPROVIDES_${PN} += "${PN}-systemd"
+RREPLACES_${PN} += "${PN}-systemd"
+RCONFLICTS_${PN} += "${PN}-systemd"

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/files/launch_cannelloni.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/files/launch_cannelloni.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Launch cannelloni at system start
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/launch_cannelloni.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/files/launch_cannelloni.sh
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/files/launch_cannelloni.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Launch cannelloni here.
+# Uncomment below line and provide valid configuration to start cannelloni at boot time
+
+#cannelloni -I slcan0 -R 127.0.0.1 -r 20000 -l 20000


### PR DESCRIPTION
GDP-710 :
Write a Yocto recipe for Cannelloni in order to compile and install it with the rest of GDP. Also write a systemd service description to start the server at boot time (for now, this is probably subject to change).

Added recipe for cannelloni and lanch cannelloni systemd service. For now lanching script does nothing. 

Task does not define where this recipe should be added. For now it has been added to:
 meta-genivi-dev/meta-genivi-dev/recipes-extended/
