### PR TITLE
Add BluetoothPairingApp

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/bluetoothpairingapp/com.genivi.gdp.bluetoothPairingApp.desktop
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/bluetoothpairingapp/com.genivi.gdp.bluetoothPairingApp.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=BluetoothPairingApp
+Type=Application
+Exec=/opt/com.genivi.gdp.bluetoothPairingApp/bin/bluetoothPairingApp -platform wayland
+Icon=file:///opt/com.genivi.gdp.bluetoothPairingApp/bluetooth.svg
+

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/bluetoothpairingapp_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/bluetoothpairingapp_git.bb
@@ -1,0 +1,39 @@
+# Copyright (C) 2017 GENIVI Alliance
+# Released under the MIT license (see LICENSE for the terms)
+
+DESCRIPTION = "Application used to pair bluetooth devices"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
+
+DEPENDS = "qtbase qtdeclarative"
+
+RDEPENDS_${PN} = "blueconnect"
+
+inherit qmake5
+
+SRC_URI = "git://github.com/dunderroffe/bluetoothPairingApp;branch=master"
+SRCREV = "ad09140f7fb2ce3056a3827729bc833fbb485e8f"
+
+APP = "com.genivi.gdp.bluetoothPairingApp"
+EXE = "bluetoothPairingApp"
+DESKTOP_FILE = "${APP}.desktop"
+SRC_URI_append = " file://${DESKTOP_FILE}"
+
+S = "${WORKDIR}/git"
+
+do_install_append() {
+     install -d ${D}/opt/${APP}/bin
+     install -m 0555 ${EXE} \
+                ${D}/opt/${APP}/bin/${EXE}
+
+     install -m 0644 ${S}/bluetooth.svg \
+                ${D}/opt/${APP}/bluetooth.svg
+
+     install -d ${D}${datadir}/applications
+     install -m 0444 ${WORKDIR}/${DESKTOP_FILE} \
+                ${D}${datadir}/applications/${DESKTOP_FILE}
+}
+
+FILES_${PN} += "\
+    /opt/${APP} \
+    "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-hmi.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-hmi.bb
@@ -21,4 +21,5 @@ RDEPENDS_${PN} += "\
     gdp-new-hmi \
     gdp-hmi-app-metadata \
     hvac \
+    bluetoothpairingapp \
     "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/blueconnect/blueconnect_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/blueconnect/blueconnect_git.bb
@@ -1,0 +1,17 @@
+# Copyright (C) 2017 GENIVI Alliance
+# Released under the MIT license (see LICENSE for the terms)
+
+DESCRIPTION = "Library for creating simple qt bluetooth demos"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
+
+DEPENDS = "qtbase qtdeclarative"
+
+inherit qmake5
+
+SRC_URI = "git://github.com/pelagicore/blueconnect;branch=master"
+SRCREV = "a14c30d5a45a7864ed942386801bb070b6128dd0"
+
+S = "${WORKDIR}/git"
+
+FILES_${PN} +=  "${libdir}/qt5/qml/com/pelagicore/bluetooth/*"


### PR DESCRIPTION
*Note:* This currently pulls from git://github.com/dunderroffe/bluetoothpairingapp (there are no genivi repo yet) which has to be changed before merging. 

Add BluetoothPairingApp and the required depenency blueConnect.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>