### PR TITLE
cannelloni: Fix license check warning

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/cannelloni.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/cannelloni.bb
@@ -1,28 +1,26 @@
 SUMMARY = "SocketCAN over Ethernet tunnel using UDP to transfer CAN frames between two machines"
 SECTION = "console/network"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPLv2;md5=B234EE4D69F5FCE4486A80FDAF4A4263"
+LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=B234EE4D69F5FCE4486A80FDAF4A4263"
+
 PR = "r0"
 
-DEPENDS = " \
-           ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
-          "
+DEPENDS = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}"
 
+SRCREV = "0fb6880b719b8acf2b4210b264b7140135e4be8a"
 SRC_URI = "git://github.com/mguentner/cannelloni \
            file://launch_cannelloni.sh \
-           file://launch_cannelloni.service "
-SRCREV = "0fb6880b719b8acf2b4210b264b7140135e4be8a"
+           file://launch_cannelloni.service"
 
 S = "${WORKDIR}/git"
 
-EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
-
 inherit pkgconfig cmake
-
 inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "launch_cannelloni.service"
 INITSCRIPT_NAME = "launch_cannelloni.sh"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 
 do_install() {
     install -d ${D}${bindir}


### PR DESCRIPTION
WARNING: cannelloni-1.0-r0 do_populate_lic: Could not copy license file
...........
[Errno 2] No such file or directory:
'.../gdp/poky/meta/files/common-licenses/GPLv2'

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>