### PR TITLE
conf: Align layer name to directory name

### DIFF
--- a/gdp-src-build/conf/layer.conf
+++ b/gdp-src-build/conf/layer.conf
@@ -5,14 +5,14 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev"
-BBFILE_PATTERN_genividev = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev = "7"
+BBFILE_COLLECTIONS += "genivi-dev"
+BBFILE_PATTERN_genivi-dev = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev = "1"
+LAYERVERSION_genivi-dev = "1"
 
-LAYERDEPENDS_genividev = "ivi"
+LAYERDEPENDS_genivi-dev = "ivi"
 
 

--- a/meta-genivi-dev/meta-erlang/conf/layer.conf
+++ b/meta-genivi-dev/meta-erlang/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev-meta-rvi-append"
-BBFILE_PATTERN_genividev-meta-erlang-append = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev-meta-erlang-append = "7"
+BBFILE_COLLECTIONS += "genivi-dev-meta-rvi-append"
+BBFILE_PATTERN_genivi-dev-meta-erlang-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-meta-erlang-append = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev-meta-erlang-append = "1"
+LAYERVERSION_genivi-dev-meta-erlang-append = "1"
 
-LAYERDEPENDS_genividev-meta-erlang-append = "genividev"
+LAYERDEPENDS_genivi-dev-meta-erlang-append = "genivi-dev"
 

--- a/meta-genivi-dev/meta-genivi-dev/conf/layer.conf
+++ b/meta-genivi-dev/meta-genivi-dev/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev"
-BBFILE_PATTERN_genividev = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev = "7"
+BBFILE_COLLECTIONS += "genivi-dev"
+BBFILE_PATTERN_genivi-dev = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev = "1"
+LAYERVERSION_genivi-dev = "1"
 
-LAYERDEPENDS_genividev = "ivi"
+LAYERDEPENDS_genivi-dev = "ivi"
 

--- a/meta-genivi-dev/meta-ivi/conf/layer.conf
+++ b/meta-genivi-dev/meta-ivi/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev-meta-ivi-append"
-BBFILE_PATTERN_genividev-meta-ivi-append = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev-meta-ivi-append = "7"
+BBFILE_COLLECTIONS += "genivi-dev-meta-ivi-append"
+BBFILE_PATTERN_genivi-dev-meta-ivi-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-meta-ivi-append = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev-meta-ivi-append = "1"
+LAYERVERSION_genivi-dev-meta-ivi-append = "1"
 
-LAYERDEPENDS_genividev-meta-ivi-append = "genividev"
+LAYERDEPENDS_genivi-dev-meta-ivi-append = "genivi-dev"
 

--- a/meta-genivi-dev/meta-qt5/conf/layer.conf
+++ b/meta-genivi-dev/meta-qt5/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev-meta-qt5-append"
-BBFILE_PATTERN_genividev-meta-qt5-append = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev-meta-qt5-append = "7"
+BBFILE_COLLECTIONS += "genivi-dev-meta-qt5-append"
+BBFILE_PATTERN_genivi-dev-meta-qt5-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-meta-qt5-append = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev-meta-qt5-append = "1"
+LAYERVERSION_genivi-dev-meta-qt5-append = "1"
 
-LAYERDEPENDS_genividev-meta-qt5-append = "genividev"
+LAYERDEPENDS_genivi-dev-meta-qt5-append = "genivi-dev"
 

--- a/meta-genivi-dev/meta-raspberrypi/conf/layer.conf
+++ b/meta-genivi-dev/meta-raspberrypi/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev-meta-raspberrypi-append"
-BBFILE_PATTERN_genividev-meta-raspberrypi-append = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev-meta-raspberrypi-append = "7"
+BBFILE_COLLECTIONS += "genivi-dev-meta-raspberrypi-append"
+BBFILE_PATTERN_genivi-dev-meta-raspberrypi-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-meta-raspberrypi-append = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev-meta-raspberrypi-append = "1"
+LAYERVERSION_genivi-dev-meta-raspberrypi-append = "1"
 
-LAYERDEPENDS_genividev-meta-raspberrypi-append = "genividev"
+LAYERDEPENDS_genivi-dev-meta-raspberrypi-append = "genivi-dev"
 

--- a/meta-genivi-dev/meta-rvi/conf/layer.conf
+++ b/meta-genivi-dev/meta-rvi/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev-meta-rvi-append"
-BBFILE_PATTERN_genividev-meta-rvi-append = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev-meta-rvi-append = "7"
+BBFILE_COLLECTIONS += "genivi-dev-meta-rvi-append"
+BBFILE_PATTERN_genivi-dev-meta-rvi-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-meta-rvi-append = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev-meta-rvi-append = "1"
+LAYERVERSION_genivi-dev-meta-rvi-append = "1"
 
-LAYERDEPENDS_genividev-meta-rvi-append = "genividev"
+LAYERDEPENDS_genivi-dev-meta-rvi-append = "genivi-dev"
 

--- a/meta-genivi-dev/poky/conf/layer.conf
+++ b/meta-genivi-dev/poky/conf/layer.conf
@@ -5,11 +5,11 @@ BBPATH =. "${LAYERDIR}:"
 BBFILES += "${LAYERDIR}/meta/recipes-*/*/*.bb \
             ${LAYERDIR}/meta/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "genividev-poky-append"
-BBFILE_PATTERN_genividev-poky-append = "^${LAYERDIR}/"
-BBFILE_PRIORITY_genividev-poky-append = "7"
+BBFILE_COLLECTIONS += "genivi-dev-poky-append"
+BBFILE_PATTERN_genivi-dev-poky-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-poky-append = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_genividev-poky-append = "1"
-LAYERDEPENDS_genividev-poky-append = "genividev"
+LAYERVERSION_genivi-dev-poky-append = "1"
+LAYERDEPENDS_genivi-dev-poky-append = "genivi-dev"


### PR DESCRIPTION
Rename layer name from "genividev" to "genivi-dev"
to be used in collections.

This way this layer can be optionally and dynamicaly overloaded by sub layer,
using this scriplet:

  BBFILES += "${@' '.join('${LAYERDIR}/meta-%s/recipes*/*/*.bb' % layer \
  for layer in BBFILE_COLLECTIONS.split())}"

This is meta-ocf-automotive strategy to support specific features
for diferents distros, for more details track:
https://wiki.iotivity.org/automotive

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>