### PR TITLE
nativesdk: Remove dnf support

### DIFF
--- a/meta-genivi-dev/poky/meta/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
+++ b/meta-genivi-dev/poky/meta/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
@@ -1,0 +1,2 @@
+RDEPENDS_${PN}_remove = "nativesdk-dnf"
+


### PR DESCRIPTION
The dependency chain for the nativesdk-dnf is currently broken. DNF is currently not used
and/or supported by the genivi-dev-platform anyways, so removing the dependency.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>