### PR TITLE
Fix build against gcc 7.1.1

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/dbus-c++/dbus-c++-native.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/dbus-c++/dbus-c++-native.bb
@@ -3,4 +3,5 @@ inherit native
 
 DEPENDS = "glib-2.0-native dbus-native expat-native"
 
-SRC_URI_append = " file://0001-Fix-build-error-in-test.patch"
+SRC_URI_append = " file://0001-Fix-build-error-in-test.patch \
+                   file://0001-Pass-correct-type-of-argument.patch "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/dbus-c++/dbus-c++.inc
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/dbus-c++/dbus-c++.inc
@@ -15,7 +15,7 @@ S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 
-EXTRA_OECONF_append = " --disable-ecore"
+EXTRA_OECONF_append = " --disable-ecore --enable-examples=no --enable-tests=no "
 
 FILES_${PN}-dbg += "${bindir}/dbusxx-xml2cpp ${bindir}/dbusxx-introspect"
 FILES_${PN}-dev += "${bindir}/.dev"

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/dbus-c++/dbus-c++/0001-Pass-correct-type-of-argument.patch
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/dbus-c++/dbus-c++/0001-Pass-correct-type-of-argument.patch
@@ -1,0 +1,25 @@
+From 668b2785ba602ed335e1c72e033328ae661adef8 Mon Sep 17 00:00:00 2001
+From: Zeeshan Ali <zeenix@gmail.com>
+Date: Thu, 7 Sep 2017 15:09:04 +0200
+Subject: [PATCH] Pass correct type of argument
+
+Even if it's allowed, passing a char to a "void *" argument seems pretty
+silly. Let's pass the correct type.
+---
+ src/pipe.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pipe.cpp b/src/pipe.cpp
+index 01211b3..b0a9539 100644
+--- a/src/pipe.cpp
++++ b/src/pipe.cpp
+@@ -83,5 +83,5 @@ ssize_t Pipe::read(void *buffer, unsigned int &nbytes)
+ void Pipe::signal()
+ {
+   // TODO: ignoring return of read/write generates warning; maybe relevant for eventloop work...
+-  ::write(_fd_write, '\0', 1);
++  ::write(_fd_write, "", 1);
+ }
+-- 
+2.13.5
+


### PR DESCRIPTION
On my Fedora 26 host, these patches are needed to get GDP build successfully.