### PR TITLE
Fix meta-erlang properly (& use temporary fork)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	url = git://github.com/GENIVI/meta-rvi.git
 [submodule "meta-erlang"]
 	path = meta-erlang
-	url = git://github.com/joaohf/meta-erlang.git
+	url = git://github.com/gunnarx/meta-erlang.git
 [submodule "meta-raspberrypi"]
 	path = meta-raspberrypi
 	url = git://git.yoctoproject.org/meta-raspberrypi

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -222,6 +222,7 @@ fi
 # go.cd when fetching materials, but materials can be overriden by FORK /
 # BRANCH / TAG / COMMIT
 echo "Submodules:"
+git submodule sync    # Because submodules may have changed
 git submodule update  # Because submodules may have changed
 git submodule status
 


### PR DESCRIPTION
The proper fix is to avoid the use of tarballs from GitHub altogether.

I've sent a PR upstream.  Using a fork in the meantime.  

(!) Untested commit, trying build.
