### PR TITLE
Erlang hotfix keeping version 18.2.3

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -10,6 +10,9 @@ LICENSE_FLAGS_WHITELIST  += "commercial"
 
 #INCOMPATIBLE_LICENSE ?= "GPLv3"
 
+PREFERRED_VERSION_erlang-native = "18.2.3"
+PREFERRED_VERSION_erlang = "18.2.3"
+
 # Disk Space Monitoring during the build
 #
 # Monitor the disk space during the build. If there is less that 1GB of space or less


### PR DESCRIPTION
New attempt.  Refer to #136 for more details.

The difference is this branches meta-erlang from the version we had, and does therefore not update to the latest tip of master.  Thus, the OTP version is held back at 18.2.3 which is what we had.  Hopefully this compiles.
