### PR TITLE
Add meta-ivi-renesas layer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "meta-flatpak"]
 	path = meta-flatpak
 	url = https://github.com/klihub/meta-flatpak
+[submodule "meta-ivi-renesas"]
+	path = meta-ivi-renesas
+	url = https://github.com/GENIVI/meta-ivi-renesas.git

--- a/gdp-src-build/conf/templates/r-car-m3-starter-kit.bblayers.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-starter-kit.bblayers.conf
@@ -5,4 +5,5 @@ BBLAYERS += " \
   ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
   ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
   ${TOPDIR}/../meta-linaro/meta-optee \
+  ${TOPDIR}/../meta-ivi-renesas \
   "

--- a/init.sh
+++ b/init.sh
@@ -92,7 +92,7 @@ function setupGitSubmodules() {
     bsparr["porter"]="meta-renesas"
     bsparr["silk"]="meta-renesas"
     bsparr["dragonboard-410c"]="meta-qcom"
-    bsparr["r-car-m3-starter-kit"]="meta-linaro meta-renesas"
+    bsparr["r-car-m3-starter-kit"]="meta-linaro meta-renesas meta-ivi-renesas"
 
     # This looks somewhat complex but the intention is to clone only needed
     # submodules.  The module list is calculated as : all the submodules we


### PR DESCRIPTION
The current Pyro/Genivi support for Renesas R-Car Gen 3 provides Pyro support only via the Yocto BSP contained in the GDP submodule meta-renesas. This PR introduces a new submodule meta-ivi-renesas which provides a yocto layer that adapts that Yocto BSP to the Genivi Yocto Baseline and meta-ivi. For example configuring Weston to use the Genivi ivi-shell and ivi-extension components. 

[GDP-744] Add new Renesas meta-ivi adaption layer

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>