### PR TITLE
Add support for Renesas R-Car H3 Starter Kit board

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "meta-flatpak"]
 	path = meta-flatpak
 	url = https://github.com/klihub/meta-flatpak
+[submodule "meta-ivi-renesas"]
+	path = meta-ivi-renesas
+	url = https://github.com/GENIVI/meta-ivi-renesas.git

--- a/gdp-src-build/conf/templates/r-car-h3-starter-kit.bblayers.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-starter-kit.bblayers.conf
@@ -1,0 +1,7 @@
+include templates/bblayers.inc
+
+# Include bblayers used for all Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.bblayers.inc
+
+# Renesas R-Car H3 Starter Kit Premium specific layer configuration
+# should be added here. None to add at this time.

--- a/gdp-src-build/conf/templates/r-car-h3-starter-kit.local.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-starter-kit.local.conf
@@ -1,0 +1,15 @@
+# Include general conf for Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.local.inc
+
+# Renesas gfx/mmp package control:
+# 1) For the Evaluation (click-through licensed) gfx/mmp packages
+#    'use_eva_pkg' must be added to DISTRO_FEATURES.
+# 2) If you are using the full version of those packages then
+#    comment out this line as it is not needed.
+DISTRO_FEATURES_append = " use_eva_pkg"
+
+# Select the H3 SoC
+SOC_FAMILY = "r8a7795"
+
+# Select the H3 Starter Kit board
+MACHINE = "h3ulcb"

--- a/gdp-src-build/conf/templates/r-car-m3-starter-kit.bblayers.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-starter-kit.bblayers.conf
@@ -1,9 +1,7 @@
 include templates/bblayers.inc
 
+# Include bblayers used for all Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.bblayers.inc
+
 # Renesas R-Car M3 Starter Kit Pro specific layer configuration
-BBLAYERS += " \
-  ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
-  ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
-  ${TOPDIR}/../meta-linaro/meta-optee \
-  ${TOPDIR}/../meta-ivi-renesas \
-  "
+# should be added here. None to add at this time.

--- a/gdp-src-build/conf/templates/r-car-m3-starter-kit.bblayers.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-starter-kit.bblayers.conf
@@ -5,4 +5,5 @@ BBLAYERS += " \
   ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
   ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
   ${TOPDIR}/../meta-linaro/meta-optee \
+  ${TOPDIR}/../meta-ivi-renesas \
   "

--- a/gdp-src-build/conf/templates/renesas-rcar-gen3.bblayers.inc
+++ b/gdp-src-build/conf/templates/renesas-rcar-gen3.bblayers.inc
@@ -1,0 +1,10 @@
+# Renesas R-Car Gen 3 (H3/M3/E3) layer configuration.
+# Place the general layer setup for Gen 3 boards in a single include
+# to avoid duplicating this information in multiple board files.
+
+BBLAYERS += " \
+  ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
+  ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
+  ${TOPDIR}/../meta-linaro/meta-optee \
+  ${TOPDIR}/../meta-ivi-renesas \
+  "

--- a/init.sh
+++ b/init.sh
@@ -92,7 +92,7 @@ function setupGitSubmodules() {
     bsparr["porter"]="meta-renesas"
     bsparr["silk"]="meta-renesas"
     bsparr["dragonboard-410c"]="meta-qcom"
-    bsparr["r-car-m3-starter-kit"]="meta-linaro meta-renesas"
+    bsparr["r-car-m3-starter-kit"]="meta-linaro meta-renesas meta-ivi-renesas"
 
     # This looks somewhat complex but the intention is to clone only needed
     # submodules.  The module list is calculated as : all the submodules we

--- a/init.sh
+++ b/init.sh
@@ -21,6 +21,7 @@ function setupGitSubmodules() {
         "porter"
         "qemux86-64"
         "r-car-m3-starter-kit"
+        "r-car-h3-starter-kit"
         "raspberrypi2"
         "raspberrypi3"
         "silk")
@@ -29,6 +30,7 @@ function setupGitSubmodules() {
         "minnowboard"
         "qemux86-64"
         "r-car-m3-starter-kit"
+        "r-car-h3-starter-kit"
         "raspberrypi2"
         "raspberrypi3")
     local modules=()
@@ -93,6 +95,7 @@ function setupGitSubmodules() {
     bsparr["silk"]="meta-renesas"
     bsparr["dragonboard-410c"]="meta-qcom"
     bsparr["r-car-m3-starter-kit"]="meta-linaro meta-renesas meta-ivi-renesas"
+    bsparr["r-car-h3-starter-kit"]="meta-linaro meta-renesas meta-ivi-renesas"
 
     # This looks somewhat complex but the intention is to clone only needed
     # submodules.  The module list is calculated as : all the submodules we


### PR DESCRIPTION
Add support for the [R-Car H3 Starter Kit Premier board](http://www.elinux.org/R-Car/Boards/H3SK) to the GDP setup scripting.

This was developed on top of PR #140 (not yet merged) so includes commit 35979c1 as its the only way for github to allow me to create the PR.

[GDP-746] Add Renesas R-Car H3 Starter Kit support to setup scripting

