### PR TITLE
Remove nativesdk-packagegroup-sdk-host.bbappend

### DIFF
--- a/meta-genivi-dev/poky/meta/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
+++ b/meta-genivi-dev/poky/meta/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
@@ -1,2 +1,0 @@
-RDEPENDS_${PN}_remove = "nativesdk-dnf"
-


### PR DESCRIPTION
meta-flatpak is updated to fix dnf parsing problem.
So nativesdk-packagegroup-sdk-host.bbappend is not required anymore.

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>