### PR TITLE
Move desktopfiles to yocto repo and start bwrapping apps

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/connectedhome.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/connectedhome.bb
@@ -4,7 +4,8 @@
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 SRC_URI = "git://github.com/GENIVI/connected-home"
-SRCREV  = "d839c4efb39ae0ad90e596d824564a0a27cf8ed7"
+SRCREV  = "2847ab9547be807d0767c69b0c0df7c90461fc6e"
+
 
 SUMMARY = "Connected Home"
 DEPENDS = "qtbase qtdeclarative"
@@ -16,5 +17,30 @@ inherit qmake5
 APP = "com.genivi.gdp.${PN}"
 EXE = "qt-smart-demo"
 
-include ics-apps.inc
+SRC_URI_append ="\
+    file://${APP}.desktop \
+    "
 
+
+do_install_append() {
+     install -Dm 644 ${WORKDIR}/git/${APP}.svg \
+                 ${D}/opt/${APP}/share/icons/${APP}.svg
+
+     install -Dm 555 ${EXE} \
+                 ${D}/opt/${APP}/bin/${EXE}
+
+     install -Dm 644 ${WORKDIR}/${APP}.desktop \
+                 ${D}/usr/share/applications/${APP}.desktop
+
+     install -d ${WORKDIR}/git/imports \
+                ${D}/opt/${APP}/bin/imports
+}
+
+FILES_${PN} += "\
+    /opt/${APP} \
+    /usr/bin/${EXE} \
+    ${libdir} \
+    ${libdir}/systemd \
+    ${libdir}/systemd/user \
+    ${libdir}/systemd/user/* \
+    "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/connectedhome/com.genivi.gdp.connectedhome.desktop
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/connectedhome/com.genivi.gdp.connectedhome.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Connected Home
+Type=Application
+Icon=file://opt/com.genivi.gdp.connectedhome/share/icons/com.genivi.gdp.connectedhome.svg
+Unit=com.genivi.gdp.connectedhome
+Exec=bwrap --ro-bind / / --dev-bind /dev/dri/ /dev/dri --unshare-user --uid 128 --gid 512 /opt/com.genivi.gdp.connectedhome/bin/qt-smart-demo -platform wayland

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
@@ -31,7 +31,4 @@ do_install_append() {
                         ${D}${libdir}/systemd/user
         mkdir -p ${D}/home/root/.config/systemd/user/default.target.wants/gdp-new-hmi.service
 	ln -sf /usr/lib/systemd/user/gdp-new-hmi.service ${D}/home/root/.config/systemd/user/default.target.wants/gdp-new-hmi.service
-	install -d ${D}/usr/share/applications/
-        install -m 0444 ${WORKDIR}/git/manifests/* \
-                        ${D}/usr/share/applications/
 }

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac.bb
@@ -4,7 +4,7 @@
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 SRC_URI = "git://github.com/GENIVI/HVAC"
-SRCREV  = "b5f215a90d7c32e75de6a5cc621f5bbc9e5617a0"
+SRCREV  = "dc5185223e7301807ce1a12c8f30528851fb4dc8"
 
 SUMMARY = "HVAC"
 DEPENDS = "qtbase qtdeclarative dbus"
@@ -14,19 +14,23 @@ S = "${WORKDIR}/git"
 
 inherit qmake5
 
+APP = "com.genivi.gdp.${PN}"
+EXE = "HVAC_rvi_vtc1010"
+
+SRC_URI_append ="\
+    file://${APP}.desktop \
+    "
+
+
 do_install_append() {
-	install -d ${D}/opt/com.genivi.gdp.hvac/bin/imports/
-        cp -fr ${S}/imports/* ${D}/opt/com.genivi.gdp.hvac/bin/imports/
-        install -d ${D}/opt/com.genivi.gdp.hvac/bin/
-	mv ${D}/opt/HVAC_rvi_vtc1010/bin/HVAC_rvi_vtc1010 \ 
-		${D}/opt/com.genivi.gdp.hvac/bin/HVAC_rvi_vtc1010
-        install -d ${D}/opt/com.genivi.gdp.hvac/share/icons/
-        install -m 0444 ${S}/com.genivi.gdp.hvac.svg \
-                        ${D}/opt/com.genivi.gdp.hvac/share/icons/com.genivi.gdp.hvac.svg
-	install -d ${D}/usr/share/applications/
-        install -m 0444 ${S}/com.genivi.gdp.hvac.desktop \
-                        ${D}/usr/share/applications/com.genivi.gdp.hvac.desktop
-	install -d ${D}${libdir}/systemd/user
+     install -Dm 0444 ${WORKDIR}/git/${APP}.svg \
+                 ${D}/opt/${APP}/share/icons/${APP}.svg
+
+     install -Dm 0555 ${EXE} \
+                 ${D}/opt/${APP}/bin/${EXE}
+
+     install -Dm 0644 ${WORKDIR}/${APP}.desktop \
+                 ${D}/usr/share/applications/${APP}.desktop
 }
 
 FILES_${PN} += "\

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac/com.genivi.gdp.hvac.desktop
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac/com.genivi.gdp.hvac.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Climate Controls
+Type=Application
+Icon=file://opt/com.genivi.gdp.hvac/share/icons/com.genivi.gdp.hvac.svg
+Unit=com.genivi.gdp.hvac
+Exec=bwrap --ro-bind / / --dev-bind /run /run --dev-bind /dev/dri/ /dev/dri --unshare-user /opt/com.genivi.gdp.hvac/bin/HVAC_rvi_vtc1010

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc-git/browser.desktop
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc-git/browser.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Browser
+Type=Application
+Icon=file://usr/share/gdp/hmi_icons_033115-4.png
+Unit=demoui
+Exec=/opt/demoui/bin/demoui -platform wayland

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc-git/browser.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc-git/browser.service
@@ -1,6 +1,0 @@
-[Unit]
-Description=Genivi Browser PoC service
-Requires=dbus.service
-
-[Service]
-ExecStart=/opt/browser/bin/browser

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc-git/demoui.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc-git/demoui.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Genivi Browser PoC demoui
-Requires=browser.service
-
-[Service]
-Environment=LD_PRELOAD=/usr/lib/libEGL.so
-ExecStart=/opt/demoui/bin/demoui

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/browser-poc/browser-poc_git.bb
@@ -9,10 +9,11 @@ SRCREV = "231265ba9cc7581f8fb36d9e7f862f211d43564a"
 
 DEPENDS = "qtbase qtwebkit"
 
+DESKTOP_FILE = "browser.desktop"
+
 SRC_URI = "git://github.com/GENIVI/browser-poc.git \
            file://browser_poc_smaller_bookmarks_qml.patch \
-           file://browser.service \
-           file://demoui.service \
+           file://${DESKTOP_FILE} \
            file://COPYING \
            file://layer_manager_surface_id.patch \
            file://0001-browser-missing-method-for-connect.patch \
@@ -37,12 +38,15 @@ do_install_append() {
     cp -r ${S}/testapp/images ${D}/opt/testapp
     cp -r ${S}/testapp/qml ${D}/opt/testapp
     mkdir -p ${D}/etc/systemd/user
-    cp ${WORKDIR}/browser.service ${WORKDIR}/demoui.service ${D}/etc/systemd/user
+
+    install -Dm 644 ${WORKDIR}/${DESKTOP_FILE} \
+                    ${D}/usr/share/applications/${DESKTOP_FILE}
 }
 
 FILES_${PN} += "/opt/browser/bin/* \
                 /opt/demoui/* \
                 /opt/testapp/* \
+                /usr/share/applications/* \
                "
 
 FILES_${PN}-dbg += "/opt/browser/bin/.debug/* \

--- a/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager-demo/AudioManager_Monitor.desktop
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager-demo/AudioManager_Monitor.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Audio Manager
+Type=Application
+Icon=file://usr/share/gdp/hmi_icons_033115-3.png
+Unit=AudioManager_Monitor
+Exec=/usr/bin/AudioManagerMonitor -platform wayland

--- a/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor.bb
@@ -7,9 +7,11 @@ DEPENDS = "qtbase qtdeclarative pulseaudio audiomanager"
 
 SRCREV = "eea896440e5ad49622c7b1a4095f0d63c3465aa2"
 
+DESKTOP_FILE = "AudioManager_Monitor.desktop"
+
 SRC_URI = "\
     git://github.com/GENIVI/audio-manager-demo.git \
-    file://AudioManager_Monitor.service \
+    file://${DESKTOP_FILE} \
     file://0001-gdp-audio-monitor-include-fix.patch \
     "
 
@@ -22,12 +24,16 @@ QMAKE_PROFILES = "${S}/"
 inherit qmake5
 
 do_install_append() {
-    mkdir -p ${D}/etc/systemd/user
-    cp ${WORKDIR}/AudioManager_Monitor.service ${D}/etc/systemd/user
+    install -Dm 644 ${WORKDIR}/${DESKTOP_FILE} \
+                    ${D}/usr/share/applications/${DESKTOP_FILE}
 }
 
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 
-FILES_${PN} += "/opt/AudioManagerMonitor/*"
+FILES_${PN} += "                           \
+                /opt/AudioManagerMonitor/* \
+                /usr/share/applications/*   \
+"
+
 FILES_${PN}-dbg += "/usr/bin/AudioManagerMonitor/.debug/*"

--- a/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor/AudioManager_Monitor.desktop
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor/AudioManager_Monitor.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Audio Manager
+Type=Application
+Icon=file://usr/share/gdp/hmi_icons_033115-3.png
+Unit=AudioManager_Monitor
+Exec=/usr/bin/AudioManagerMonitor -platform wayland

--- a/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor/AudioManager_Monitor.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor/AudioManager_Monitor.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=Genivi AudioManager PoC
-Requires=pulseaudio.service AudioManager.service
-
-[Service]
-Environment=DBUS_FATAL_WARNINGS=0
-Environment=LD_PRELOAD=/usr/lib/libEGL.so.1
-ExecStart=/usr/bin/AudioManagerMonitor

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLInputEventExample.desktop
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLInputEventExample.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Input Example
+Type=Application
+Icon=
+Unit=EGLWLInputEventExample
+Exec=/usr/bin/EGLWLInputEventExample -platform wayland

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLInputEventExample.desktop
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLInputEventExample.desktop
@@ -3,4 +3,4 @@ Name=Input Example
 Type=Application
 Icon=
 Unit=EGLWLInputEventExample
-Exec=/usr/bin/EGLWLInputEventExample -platform wayland
+Exec=bwrap --ro-bind / / --dev-bind /dev/dri/ /dev/dri --unshare-user --uid 128 --gid 512 /usr/bin/EGLWLInputEventExample -platform wayland

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLInputEventExample.service
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLInputEventExample.service
@@ -1,5 +1,0 @@
-[Unit]
-Description=EGL Wayland Input Event Example
-
-[Service]
-ExecStart=/usr/bin/EGLWLInputEventExample

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLMockNavigation.desktop
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLMockNavigation.desktop
@@ -3,4 +3,4 @@ Name=Mock Navigation
 Type=Application
 Icon=file://usr/share/gdp/hmi_icons_033115-2.png
 Unit=EGLWLMockNavigation
-Exec=/usr/bin/EGLWLMockNavigation -platform wayland
+Exec=bwrap --ro-bind / / --dev-bind /dev/dri/ /dev/dri --unshare-user --uid 128 --gid 512 /usr/bin/EGLWLMockNavigation -platform wayland

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLMockNavigation.desktop
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLMockNavigation.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Mock Navigation
+Type=Application
+Icon=file://usr/share/gdp/hmi_icons_033115-2.png
+Unit=EGLWLMockNavigation
+Exec=/usr/bin/EGLWLMockNavigation -platform wayland

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLMockNavigation.service
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension/EGLWLMockNavigation.service
@@ -1,5 +1,0 @@
-[Unit]
-Description=EGL Wayland Mock Navigation
-
-[Service]
-ExecStart=/usr/bin/EGLWLMockNavigation

--- a/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_%.bbappend
+++ b/meta-genivi-dev/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_%.bbappend
@@ -1,21 +1,25 @@
-# Copyright (C) 2015 GENIVI Alliance
+# Copyright (C) 2017 GENIVI Alliance
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 
-SRC_URI_append = "\
-    file://EGLWLInputEventExample.service \
-    file://EGLWLMockNavigation.service \
+INPUT_EXAMPLE_DESKTOP_FILE="EGLWLInputEventExample.desktop"
+MOCK_NAVIGATION_DESKTOP_FILE="EGLWLMockNavigation.desktop"
+
+SRC_URI_append = "                         \
+    file://${INPUT_EXAMPLE_DESKTOP_FILE}   \
+    file://${MOCK_NAVIGATION_DESKTOP_FILE} \
     "
 
 FILES_${PN} += "\
-    ${libdir}/systemd/user/* \
+    /usr/share/applications/* \
     "
 
 do_install_append() {
-	install -d ${D}${libdir}/systemd/user
-	install -m 0444 ${WORKDIR}/EGLWLInputEventExample.service \
-	                ${D}${libdir}/systemd/user
-	install -m 0444 ${WORKDIR}/EGLWLMockNavigation.service \
-	                ${D}${libdir}/systemd/user
+  install -Dm 0644 ${WORKDIR}/${INPUT_EXAMPLE_DESKTOP_FILE}   \
+                   ${D}/usr/share/applications/${INPUT_EXAMPLE_DESKTOP_FILE}
+
+  install -Dm 0644 ${WORKDIR}/${MOCK_NAVIGATION_DESKTOP_FILE} \
+                   ${D}/usr/share/applications/${MOCK_NAVIGATION_DESKTOP_FILE}
 }
+


### PR DESCRIPTION
Move all desktop files from application repositories to the genivi-dev-platform yocto layer.

This pull-request also makes the "Connected Home" app run in bubblewrap.