### PR TITLE
qtwayland: fix R-Car M3 Starter Kit gdp hmi startup issue

### DIFF
--- a/meta-genivi-dev/meta-qt5/recipes-qt/qt5/qtwayland_%.bbappend
+++ b/meta-genivi-dev/meta-qt5/recipes-qt/qt5/qtwayland_%.bbappend
@@ -6,3 +6,4 @@ SRC_URI_append = "\
 "
 
 DEPENDS_append_koelsch = " libegl gles-user-module"
+DEPENDS_append_rcar-gen3 = " mesa"


### PR DESCRIPTION
**Usage Note**
When building GDP-13 for R-Car Gen 3 please use the YBSP v2.23 (Weston 2.0) gfx driver package download from [here](https://www.renesas.com/en-us/solutions/automotive/rcar-demoboard-2.html). If you use the YBSP v2.19 package used with GDP-12 the screen image will be inverted.

**Description**
Fix qtwayland configure error that results in the wayland_egl plug-in
not being built and therefore not shipped in the rootfs. The missing
files result in the gdp hmi launcher failing to start with the systemd
journal error message:
Failed to load client buffer integration: wayland-egl

[GDP-752] QtWayland configure failure for wayland_egl plug-in
[GDP-753] GDP HMI fails to launch on R-Car M3 Starter Kit

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>