### PR TITLE
readme: add Renesas R-Car H3 Starter Kit, update R-Car text

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To initiate the build environment:
     source init.sh $target
 
 The current supported targets are qemux86-64, porter, raspberrypi2, raspberrypi3,
-minnowboard, silk and r-car-m3-starter-kit.
+minnowboard, silk, r-car-m3-starter-kit and r-car-h3-starter-kit.
 Currently this requires the use of the bash shell
 
 The `init.sh` script handles the the `$target` specific bitbake configuration.

--- a/meta-genivi-dev/README.md
+++ b/meta-genivi-dev/README.md
@@ -79,20 +79,14 @@ URI: git://git.yoctoproject.org/meta-raspberrypi
 * branch:   pyro
 
 ## The Renesas R-Car Gen3 M3/H3 Starter Kit boards depend in addition on: ##
-URI: https://github.com/slawr/renesas-rcar-gen3.git
-* branch: genivi-11
+URI: https://github.com/slawr/meta-renesas.git
+* branch: pyro
+
+URI: https://github.com/GENIVI/meta-ivi-renesas.git
+* branch: genivi-13
 
 URI: https://git.linaro.org/openembedded/meta-linaro.git
-* branch: krogoth
-
-## The Renesas R-Car Gen3 M3/H3 Starter Kit boards depend in addition on: ##
-URI: https://github.com/slawr/renesas-rcar-gen3.git
-* branch: genivi-11
-* revision: 4758a558bb3badd7108b04b8c43a8a3fbe61b958
-
-URI: https://git.linaro.org/openembedded/meta-linaro.git
-* branch: krogoth
-* revision: 2f51d38048599d9878f149d6d15539fb97603f8f
+* branch: pyro
 
 ## The Renesas R-Car Gen2 Silk & Porter boards depend in addition on: ##
 URI: git://github.com/slawr/meta-renesas.git
@@ -115,6 +109,7 @@ We aim to support the builds for these machines:
 * Renesas R-Car Gen2 (R-Car M2)  - machine: porter
 * Renesas R-Car Gen2 (R-Car E2)  - machine: silk
 * Renesas R-Car Gen3 (R-Car M3)  - machine: r-car-m3-starter-kit
+* Renesas R-Car Gen3 (R-Car H3)  - machine: r-car-h3-starter-kit
 * Intel Minnowboard MAX (x86-64) - machine: minnowboard
 * Raspberry Pi 2                 - machine: raspberrypi2
 * Raspberry Pi 3                 - machine: raspberrypi3


### PR DESCRIPTION
Now Renesas R-Car H3 Starter Kit has been added to the GDP automated
setup system add details for it to the readme files.

At the same time take the opportunity to bring R-Car information in
the readme files up to date.

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>