### PR TITLE
python-pyqt_5.3.1: Use ${SOURCEFORGE_MIRROR}

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-devtools/python/python-pyqt_5.3.1.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-devtools/python/python-pyqt_5.3.1.bb
@@ -14,7 +14,7 @@ PYQT_OE_VERSION = "Qt_5_3_1"
 PR = "r1"
 
 SRC_URI = "\
-    http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.3.1/PyQt-gpl-5.3.1.tar.gz \
+    ${SOURCEFORGE_MIRROR}/projects/pyqt/files/PyQt5/PyQt-5.3.1/PyQt-gpl-5.3.1.tar.gz \
     file://qpycore.pro \
     file://qpygui.pro \
     file://dbus.pro \


### PR DESCRIPTION
Other layers (poky, meta-openembedded) use the $SOURCEFORGE_MIRROR
variable (somewhat consistently) to indicate the preferred mirror when
defining SRC_URI.

This component was hardcoded to https://download.sourceforge.net, but it
should respect the SOURCEFORGE_MIRROR variable instead.

This was found when sourceforge was down a few weeks ago, although
switching mirror did not help much at that time, since basically all
mirrors seemed to have been taken down temporarily.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>