### PR TITLE
CI: enable override of one particular layer version

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -486,6 +486,12 @@ if [[ "$CREATE_RELEASE_DIR" == "true" ]]; then
   set -e
 fi
 
-echo Artifacts in staging/
-ls -R staging/
+echo "Artifacts in staging/"
+ls -al staging/
+echo
+echo "...in staging/images/ :"
+ls -al staging/images
+echo
+echo -n "Counting entries in staging/licenses : "
+ls staging/licenses | wc -l
 


### PR DESCRIPTION

Enables building a version of GDP parent project, with a particular layer exchanged for a different version.
Launching various on-demand build checks and other CI scenarios is easily 
done by setting new environment variables, per layer.

There are a few more commits here, with cleanup etc.
