### PR TITLE
ci-build.sh: Add GENIVI MIRROR + PREMIRROR option

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -247,6 +247,8 @@ define_with_default BUILD_SDK false
 define_with_default COPY_LICENSES false
 define_with_default LAYER_ARCHIVE false
 define_with_default CREATE_RELEASE_DIR false
+define_with_default MIRROR "https://docs.projects.genivi.org/releases/yocto_mirror"
+define_with_default PREMIRROR ""  # By default none (but we have the shared DL_DIR)
 define_with_default RM_WORK false
 define_with_default REUSE_STANDARD_DL_DIR true
 define_with_default REUSE_STANDARD_SSTATE_DIR true
@@ -315,6 +317,8 @@ echo "BUILD_SDK = $BUILD_SDK"
 echo "COPY_LICENSES" = "$COPY_LICENSES"
 echo "CREATE_RELEASE_DIR" = "$CREATE_RELEASE_DIR"
 echo "DL_DIR = $DL_DIR"
+echo "MIRROR" = "$MIRROR"
+echo "PREMIRROR" = "$PREMIRROR"
 echo "REUSE_STANDARD_DL_DIR = $REUSE_STANDARD_DL_DIR"
 echo "REUSE_STANDARD_SSTATE_DIR = $REUSE_STANDARD_SSTATE_DIR"
 echo "RM_WORK = $RM_WORK"
@@ -452,6 +456,32 @@ fi
 if [[ "$COPY_LICENSES" == "true" ]]; then
   append_local_conf 'COPY_LIC_DIRS = "1"'
   append_local_conf 'COPY_LIC_MANIFEST = "1"'
+fi
+
+# The own-mirrors bbclass is generally more convenient for PREMIRRORS, but
+# this format makes it similar to the $MIRROR setup below, which needs to be
+# explicit anyhow.
+if [[ -n "$PREMIRROR" ]]; then
+  append_local_conf "
+PREMIRRORS_prepend = \"\\
+     git://.*/.* $PREMIRROR \\n \\
+     ftp://.*/.* $PREMIRROR \\n \\
+     http://.*/.* $PREMIRROR \\n \\
+     https://.*/.* $PREMIRROR \\n \\
+     \"
+"
+fi
+
+# This is the "post" mirror (i.e. checked last).
+if [[ -n "$MIRROR" ]]; then
+  append_local_conf "
+MIRRORS_append = \"\\
+     git://.*/.* $MIRROR \\n \\
+     ftp://.*/.* $MIRROR \\n \\
+     http://.*/.* $MIRROR \\n \\
+     https://.*/.* $MIRROR \\n \\
+     \"
+"
 fi
 
 if [[ "$BUILD_SDK" != "true" ]]; then


### PR DESCRIPTION
Adding environment variables to define MIRRORS and PREMIRRORS variables. Only one URL for each is supported here.  PREMIRROR is by default empty, and MIRROR is by default set to a GENIVI hosted mirror.  (MIRRORS is used by Yocto as a fallback if all other source fetch options failed)

For PREMIRRORS it is normally more convenient to use the own-mirrors BB class, but since MIRRORS need to be explicitly defined, I used the same format for PREMIRRORS.

It's quite arbitrary but I chose to apply the PREMIRROR definition first (prepend) and MIRROR definition last (append), in case there were any settings already.  Seems somewhat logical that this is the desired
behavior.

NOTE that keeping the GENIVI mirror automatically up to date is not yet implemented, but the content is up to date with 13.0 release.  In any case :  

1. Only what _is_ available there will be fetched.
2. Since it is used for MIRROR, not PREMIRROR, it's only used as a fallback if local DL_DIR, and upstream URLs fail.  => It is no worse than without the mirror.

NOTE2 : I tested that the syntax of appending to local conf seems correct.  
Fetching from the mirror also seems to work fine.

