### PR TITLE
Update meta-ivi & configure hardening flags

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -13,6 +13,15 @@ LICENSE_FLAGS_WHITELIST  += "commercial"
 PREFERRED_VERSION_erlang-native = "18.2.3"
 PREFERRED_VERSION_erlang = "18.2.3"
 
+# Blacklist for compilation hardening flags.
+# The poky-ivi-systemd distro file in meta-ivi includes security_flags.inc
+# Some packages apparently fail if (some) flags are applied, so they are
+# updated here to not apply them, or apply them partially.  This lists the
+# packages that are in GDP only, not in meta-ivi.
+SECURITY_CFLAGS_pn-dbus-c++ = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-python-uinput = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-python-storm = "${SECURITY_NO_PIE_CFLAGS}"
+
 # Disk Space Monitoring during the build
 #
 # Monitor the disk space during the build. If there is less that 1GB of space or less


### PR DESCRIPTION
Nitpick: the commit comment says it is updating to master.  In reality I pushed branch wip_hardening_flags to GENIVI/meta-ivi so the commit can be referenced from GDP while it's still only an open PR in meta-ivi.
If we merge that without additional changes, the commit history and "latest master" will be correct.  Otherwise I can rewrite this commit to match.

(see commit comment for log)

