### PR TITLE
Adding h3ulcb as a compatible machine for chromium-wayland

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -29,6 +29,7 @@ COMPATIBLE_MACHINE_armv7ve = "(.*)"
 # Renesas workarounds
 
 COMPATIBLE_MACHINE_m3ulcb = "(.*)"
+COMPATIBLE_MACHINE_h3ulcb = "(.*)"
 
 # Apply same TUNE_FEATURES as in an armv7a build
 ARMFPABI_armv7ve = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'arm_float_abi=hard', 'arm_float_abi=softfp', d)}"


### PR DESCRIPTION
chromium-wayland: Adding h3ulcb as a compatible machine.

Building GDP image for r-car-h3-starter-kit target is currently not possible as h3ulcb is not set as compatible for chromium-wayland. This commit is fixing the issue.

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@mobica.com>