### PR TITLE
chromium-wayland: Depend on wayland-ivi-extension

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-DEPENDS += "mesa"
+DEPENDS += "mesa wayland-ivi-extension"
 DEPENDS_append_rcar-gen3 = " libgbm"
 
 SRC_URI += "\


### PR DESCRIPTION
Occasionally we had a compile error where the header file ilm_common.h
was not found during compilation of chromium-wayland.  This header comes
from wayland-ivi-extension.  The error seems to have gone away (or is
depending on some random build order?).  In any case I can't imagine
anything else than that the version of chromium-wayland we build should
DEPEND on wayland-ivi-extension.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>