### PR TITLE
fix build error: meta-erlang

### DIFF
--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -17,6 +17,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-gnome \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-qt5 \
+  ${TOPDIR}/../meta-genivi-dev/meta-erlang \
   ${TOPDIR}/../meta-genivi-dev/meta-genivi-dev \
   ${TOPDIR}/../meta-oic \
   ${TOPDIR}/../meta-iot-web \


### PR DESCRIPTION
Fetching meta-erlang is fixed and pull request is sent.
(https://github.com/GENIVI/meta-genivi-dev/pull/97)