### PR TITLE
[WIP] GDP-722: List all used services and make sure they have a dedicated user

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker/ambd.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker/ambd.service
@@ -8,6 +8,7 @@ After=syslog.target
 
 [Service]
 Type=dbus
+User=ambd
 BusName=org.automotive.message.broker
 ExecStart=/usr/bin/ambd
 

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://github.com/otcshare/automotive-message-broker/wiki"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b42382de5d854b9bb598acf2e8827de3"
 
-inherit cmake systemd
+inherit cmake systemd useradd
 
 PV = "0.14+git${SRCPV}"
 
@@ -23,6 +23,9 @@ EXTRA_OECMAKE += "-Denable_icecc=OFF"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "ambd.service"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} = "--system --shell /bin/false ambd"
 
 S = "${WORKDIR}/git"
 

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/aktualizr/aktualizr_git.bb
@@ -6,7 +6,7 @@ SECTION = "base"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
-inherit cmake systemd
+inherit cmake systemd useradd
 
 S = "${WORKDIR}/git"
 
@@ -23,6 +23,9 @@ DEPENDS = "boost curl openssl jansson dbus"
 
 EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DBUILD_GENIVI=ON"
 
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} = "--system --shell /bin/false aktualizr"
+
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/build/aktualizr ${D}${bindir}/
@@ -30,10 +33,14 @@ do_install() {
     install -c ${S}/dbus/org.genivi.SotaClient.conf ${D}${sysconfdir}/dbus-1/system.d
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/aktualizr.service ${D}${systemd_system_unitdir}
+
+    mkdir ${D}${sysconfdir}/sota_certificates
+    chown aktualizr.aktualizr ${D}${sysconfdir}/sota_certificates
 }
 
 FILES_${PN} = " \
     ${sysconfdir}/dbus-1/system.d/org.genivi.SotaClient.conf \
     ${bindir}/aktualizr \
     ${systemd_system_unitdir}/aktualizr.service \
+    ${sysconfdir}/sota_certificates \
     "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/aktualizr/files/aktualizr.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/aktualizr/files/aktualizr.service
@@ -8,6 +8,7 @@ Requires=network-online.target
 RestartSec=5
 Restart=on-failure
 TimeoutStopSec=5
+User=aktualizr
 ExecStartPre=/bin/echo "Loading, please wait..."
 ExecStartPre=/bin/sleep 45
 ExecStart=/usr/bin/aktualizr --config /etc/sota.toml

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/0001-common-settings-update-DB_URL-to-var-run-swm-swlm.sq.patch
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/0001-common-settings-update-DB_URL-to-var-run-swm-swlm.sq.patch
@@ -1,0 +1,41 @@
+From 69ee3d50bd26ff6708327558d0e7933136631c6c Mon Sep 17 00:00:00 2001
+From: Mirza Krak <mirza.krak@endian.se>
+Date: Thu, 3 May 2018 12:42:52 +0200
+Subject: [PATCH 1/1] common: settings: update DB_URL to
+ /var/run/swm/swlm.sqlite
+
+/var/run is root owned, and if we run the software_loading_module as a
+non-root user we will have issues with maintaining permissions, even if
+we can create an initial file with the correct permissions. If the
+process attempts to re-create the database it will need to remove the
+current file and fail when trying to create a new file in a root owned
+directory
+
+By moving the swl.sqlite file to /var/run/swm, we can control the
+permission of the "swm" directory allowing processes running under the
+same user/owner as the directory to modify its content to the fullest.
+
+Signed-off-by: Mirza Krak <mirza.krak@endian.se>
+
+Upstream: pending
+
+---
+ common/settings.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/settings.py b/common/settings.py
+index 8cf44efe6b85..19af8b30e9ec 100755
+--- a/common/settings.py
++++ b/common/settings.py
+@@ -29,7 +29,7 @@ HMI_ENABLED = str2bool(os.getenv('SLM_HMI_ENABLED', 'false'))
+
+ # Database Settings
+ # SWM operations and their results are stored in a SQLite database.
+-DB_URL = "sqlite:/var/run/swlm.sqlite"
++DB_URL = "sqlite:/var/run/swm/swlm.sqlite"
+
+ # Logging settings
+ LOGGER = 'swm.default'
+--
+2.16.2
+

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/lifecycle_manager.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/lifecycle_manager.service
@@ -8,6 +8,7 @@ Requires=network-online.target
 Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 ExecStart=/usr/bin/python /usr/lib/genivi-swm/lifecycle_manager/lifecycle_manager.py fg
+User=swm
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/module_loader_ecu1.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/module_loader_ecu1.service
@@ -8,6 +8,7 @@ Requires=network-online.target
 Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 ExecStart=/usr/bin/python /usr/lib/genivi-swm/module_loader_ecu1/module_loader_ecu1.py fg
+User=swm
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/org.genivi.SoftwareLoadingManager.conf
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/org.genivi.SoftwareLoadingManager.conf
@@ -1,7 +1,7 @@
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-    <policy user="root">
+    <policy user="swm">
         <allow own="org.genivi.SoftwareLoadingManager"/>
         <allow own="org.genivi.PartitionManager"/>
         <allow own="org.genivi.LifecycleManager"/>

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/package_manager.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/package_manager.service
@@ -10,6 +10,7 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Environment=SLM_PACKAGE_MANAGER=rpm
 Environment=SLM_SWM_SIMULATION=false
 ExecStart=/usr/bin/python /usr/lib/genivi-swm/package_manager/package_manager.py fg
+User=swm
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/partition_manager.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/partition_manager.service
@@ -9,6 +9,7 @@ Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Environment=SLM_SWM_SIMULATION=false
 ExecStart=/usr/bin/python /usr/lib/genivi-swm/partition_manager/partition_manager.py fg
+User=swm
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/software_loading_manager.service
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/software_loading_manager.service
@@ -10,6 +10,7 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Environment=SLM_PACKAGE_MANAGER=rpm
 Environment=SLM_SWM_SIMULATION=false
 ExecStart=/usr/bin/python /usr/lib/genivi-swm/software_loading_manager/software_loading_manager.py fg
+User=swm
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/swm.conf
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/files/swm.conf
@@ -1,0 +1,1 @@
+d /var/run/swm  0770 swm swm -

--- a/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/genivi-swm_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-sota/genivi-swm/genivi-swm_git.bb
@@ -12,6 +12,8 @@ SRC_URI = "\
     file://software_loading_manager.service \
     file://module_loader_ecu1.service \
     file://org.genivi.SoftwareLoadingManager.conf \
+    file://0001-common-settings-update-DB_URL-to-var-run-swm-swlm.sq.patch \
+    file://swm.conf \
     "
 
 PR = "r0"
@@ -27,6 +29,7 @@ FILES_${PN} = " \
     ${systemd_system_unitdir}/lifecycle_manager.service \
     ${sysconfdir}/dbus-1/system.d/org.genivi.SoftwareLoadingManager.conf \
     ${bindir}/sota-demo-reset.sh \
+    ${libdir}/tmpfiles.d \
     "
 
 DEPENDS = "systemd"
@@ -40,14 +43,21 @@ RDEPENDS_${PN} = " \
     rpm \
     "
 
-inherit systemd
+inherit systemd useradd
 SYSTEMD_SERVICE_${PN} = "package_manager.service partition_manager.service module_loader_ecu1.service software_loading_manager.service lifecycle_manager.service"
 
+USERADD_PACKAGES = "${PN}"
+
+# Database is stored in home folder, home folder is created using systemd
+# tmpfiles.d
+USERADD_PARAM_${PN} = "--system --shell /bin/false \
+                       --home /var/run/swm --user-group swm"
+
 do_install () {
-    install -d ${D}${libdir}/${PN}
+    install -o swm -d ${D}${libdir}/${PN}
 
     # TODO: Probably want to just copy in the needed files
-    cp -r ${S}/* ${D}${libdir}/${PN}
+    cp --no-preserve=ownership -r ${S}/* ${D}${libdir}/${PN}
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 -c "${WORKDIR}/package_manager.service" ${D}${systemd_system_unitdir}
@@ -61,4 +71,7 @@ do_install () {
 
     install -d ${D}${bindir}
     install -m 0755 -c "${S}/nano_samples_rpi/sota-demo-reset.sh" ${D}${bindir}
+
+    install -d ${D}${libdir}/tmpfiles.d
+    install -m 644 ${WORKDIR}/swm.conf ${D}${libdir}/tmpfiles.d/swm.conf
 }


### PR DESCRIPTION
Supersedes #144 

Verified that the following services at least start:

- package_manager.service
- aktualizr.service
- ambd.service
- lifecycle_manager.service
- module_loader_ecu1.service
- partition_manager.service
- software_loading_manager.service

I do not yet know how to run-time test them and to what extent they are to be tested. I am pretty sure that "swm" services will not work without additional changes. E.g running "rpm/dpkg" requires elevated privileges which the current user (swm) does not have.

HMI is left out, since we need to change Weston first to launch with the "display" group.

Still putting this out there for initial review.