### PR TITLE
[GDP-252] Add support for udisks2 to the GDP image

### DIFF
--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -24,6 +24,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-genivi-dev/meta-ivi \
   ${TOPDIR}/../meta-genivi-dev/meta-qt5 \
   ${TOPDIR}/../meta-genivi-dev/meta-rvi \
+  ${TOPDIR}/../meta-genivi-dev/meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-genivi-dev/poky \
   ${TOPDIR}/../meta-oic \
   ${TOPDIR}/../meta-iot-web \

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-dev.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-dev.bb
@@ -17,4 +17,6 @@ RDEPENDS_${PN} += "\
     openssh-sftp-server \
     connman-client \
     cannelloni \
+    udisks2 \
+    udisks2-disk-manager \
     "

--- a/meta-genivi-dev/meta-openembedded/meta-oe/conf/layer.conf
+++ b/meta-genivi-dev/meta-openembedded/meta-oe/conf/layer.conf
@@ -1,0 +1,16 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH =. "${LAYERDIR}:"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "genivi-dev-meta-oe-append"
+BBFILE_PATTERN_genivi-dev-meta-oe-append = "^${LAYERDIR}/"
+BBFILE_PRIORITY_genivi-dev-meta-oe-append = "7"
+
+# This should only be incremented on significant changes that will
+# cause compatibility issues with other layers
+LAYERVERSION_genivi-dev-meta-oe-append = "1"
+
+LAYERDEPENDS_genivi-dev-meta-oe-append = "genivi-dev"

--- a/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/org.freedesktop.UDisks2.conf
+++ b/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/org.freedesktop.UDisks2.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Only root can own the service -->
+  <policy user="root">
+    <allow own="org.freedesktop.UDisks2"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="*"/>
+    <allow send_interface="*"/>
+  </policy>
+</busconfig>

--- a/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/udisks2-disk-manager.service
+++ b/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/udisks2-disk-manager.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Udisks2 Disk Manager (automount of USB storage devices)
+
+Requires=udisks2.service
+After=udisks2.service
+
+[Service]
+ExecStart=/usr/libexec/udisks2/udisks2-disk-manager.sh
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/udisks2-disk-manager.sh
+++ b/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/udisks2-disk-manager.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Script from https://wiki.archlinux.org/index.php/udisks
+
+pathtoname() {
+    udevadm info -p /sys/"$1" | awk -v FS== '/DEVNAME/ {print $2}'
+}
+
+stdbuf -oL -- udevadm monitor --udev -s block | while read -r -- _ _ event devpath _; do
+        if [ "$event" = add ]; then
+            devname=$(pathtoname "$devpath")
+            udisksctl mount --block-device "$devname" --no-user-interaction
+        fi
+done

--- a/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/udisks2_%.bbappend
+++ b/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/udisks2_%.bbappend
@@ -1,0 +1,34 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://org.freedesktop.UDisks2.conf \
+    file://udisks2-disk-manager.service \
+    file://udisks2-disk-manager.sh \
+"
+
+do_install_append () {
+    install -d ${D}${sysconfdir}/dbus-1/system.d
+    install -m 644 ${WORKDIR}/org.freedesktop.UDisks2.conf \
+                   ${D}${sysconfdir}/dbus-1/system.d/
+
+    install -d ${D}${base_libdir}/systemd/system
+    install -m 0644 ${WORKDIR}/udisks2-disk-manager.service \
+                    ${D}${systemd_system_unitdir}
+
+    install -d ${D}${libexecdir}
+    install -m 0755 ${WORKDIR}/udisks2-disk-manager.sh \
+                    ${D}${libexecdir}/udisks2/udisks2-disk-manager.sh
+}
+
+PACKAGES += "${PN}-disk-manager"
+
+SYSTEMD_PACKAGES += "${PN}-disk-manager"
+SYSTEMD_SERVICE_${PN}-disk-manager = "udisks2-disk-manager.service"
+SYSTEMD_AUTO_ENABLE_${PN}-disk-manager = "enable"
+
+FILES_${PN} += "${sysconfdir}/dbus-1/system.d/org.freedesktop.UDisks2.conf"
+
+FILES_${PN}-disk-manager = "\
+    ${systemd_system_unitdir}/udisks2-disk-manager.service \
+    ${libexecdir}/udisks2/udisks2-disk-manager.sh \
+"


### PR DESCRIPTION
This pull-request will add udisks2 to the GDP image, along with a example service to auto-mount storage devices on hot-plug events.

Note that the D-Bus policy is very permissive.

I am a bit unsure if `packagegroup-gdp-dev"  was the correct location to these packages. If there is a more appropriate group that we should add these please let me know.