### PR TITLE
[GDP-791] systemd: Configure without polkit (for now)

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-core/systemd/systemd_%.bbappend
@@ -15,3 +15,8 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/unfocused.target ${D}${systemd_system_unitdir}/unfocused.target
     install -m 0644 ${WORKDIR}/lazy.target      ${D}${systemd_system_unitdir}/lazy.target
 }
+
+# udisks2 depends on polkit systemd.bb conflicts with polkit.bb on
+# installation.  We assume not to use polkit for systemd here - see commit
+# message for more info.
+PACKAGECONFIG_remove = "polkit"


### PR DESCRIPTION
udisks2 depends on polkit which installs the same catalog as the systemd.bb does if **PACKAGECONFIG[polkit]** is enabled. 

Example, raspberry pi build:

```
02:39:24.505   file /usr/share/polkit-1/rules.d conflicts between attempted installs of systemd-1:234-r0.cortexa7hf_neon_vfpv4 and polkit-0.113-r0.cortexa7hf_neon_vfpv4
```

There seems to be two options: - keep polkit enabled for systemd but redefine the installation step to fix the conflict for the directory installation, or remove polkit feature in systemd build.

Disabling the feature will also configure systemd build with --disable-polkit.

What is it used for?    Polkit can be used to control which systemd services can be controlled
by regular users.  I am guessing  that feature is not required here and it seems more tailored for a multi-user "desktop" situation.  

Assuming that we don't use polkit with systemd now, the feature can simply be avoided for the moment.
If it's ever needed again, then the other solution can be investigated.
