### PR TITLE
templates: local.inc: remove package_rpm

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -2,7 +2,7 @@
 
 DISTRO ?= "poky-ivi-systemd"
 USE_GSTREAMER_1_00 ?= "1"
-PACKAGE_CLASSES ?= "package_rpm package_ipk"
+PACKAGE_CLASSES ?= "package_ipk"
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 PATCHRESOLVE ?= "noop"

--- a/gdp-src-build/conf/templates/renesas-rcar-gen3.local.inc
+++ b/gdp-src-build/conf/templates/renesas-rcar-gen3.local.inc
@@ -19,8 +19,6 @@ SOC_FAMILY ?= "r8a7796"
 # Linaro GCC
 GCCVERSION = "linaro-5.3"
 
-PACKAGE_CLASSES = "package_rpm"
-
 # add the static lib to SDK toolchain
 SDKIMAGE_FEATURES_append = " staticdev-pkgs"
 


### PR DESCRIPTION
RPM was our primary package manager which means that the
do_rootfs would use dnf to install all the required packages.

Currently RPM has performance issues when running inside a
docker container, which our builds normally do on our build
servers but it is also quite common to run this on developer
machines as well.

The performance issues are rapported and fixed in upstream RPM,
https://bugzilla.redhat.com/show_bug.cgi?id=1537564.

But since we do not rely on using RPM we simply remove it instead
of trying to backport and maintain a patchset for a couple of
Yocto release. Currently only poky/master has the "fixed" RPM
package.

[GDP-793] rpm in docker is slowing down builds

Signed-off-by: Mirza Krak <mirza.krak@endian.se>