### PR TITLE
GDP-787 - Remove dev files from target image

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -36,4 +36,4 @@ CONF_VERSION = "1"
 # Support OE QA test suite export with bitbake -c testexport <image name>
 INHERIT += "testexport"
 TEST_EXPORT_ONLY = "1"
-TEST_SUITES = "ping ssh scp date dmesg connman systemd gdp"
+TEST_SUITES = "ping ssh scp date dmesg connman systemd gdp devpackages"

--- a/meta-genivi-dev/meta-genivi-dev/lib/oeqa/runtime/cases/devpackages.py
+++ b/meta-genivi-dev/meta-genivi-dev/lib/oeqa/runtime/cases/devpackages.py
@@ -1,0 +1,18 @@
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.core.decorator.depends import OETestDepends
+from oeqa.core.decorator.oeid import OETestID
+
+# Make sure that dev-pkgs are not installed unless explicitly enabled
+# in IMAGE_FEATURES
+class DevPackages(OERuntimeTestCase):
+
+    @OETestID(2001)
+    @OETestDepends(['ssh.SSHTest.test_ssh'])
+    def test_dev_packages(self):
+        if ('dev-pkgs' in self.tc.td.get('IMAGE_FEATURES', '')) :
+            self.skipTest('Found dev-pkgs in IMAGE_FEATURES')
+
+        (status, output) = self.target.run('test -e /usr/include/stdint.h')
+        msg = ('Development files found on target %s' %
+              self.target.run('ls /usr/include/')[1])
+        self.assertNotEqual(status, 0, msg=msg)

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -27,7 +27,6 @@ IMAGE_INSTALL_append = " \
     packagegroup-specific-component-p1 \
     packagegroup-gdp-am-demo \
     packagegroup-gdp-browser \
-    packagegroup-gdp-fsa \
     packagegroup-gdp-gps \
     packagegroup-gdp-hmi \
     packagegroup-iotivity \

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-dev.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-dev.bb
@@ -14,6 +14,7 @@ PACKAGES = "\
 ALLOW_EMPTY_${PN} = "1"
 
 RDEPENDS_${PN} += "\
+    avahi-daemon \
     openssh-sftp-server \
     connman-client \
     cannelloni \

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-gps.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-gps.bb
@@ -20,7 +20,6 @@ RDEPENDS_${PN} += "\
     gpsd \
     gps-utils \
     gpsd-conf \
-    gpsd-dev \
     gpsd-gpsctl \
     gpsd-udev \
     libgps \

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
@@ -33,6 +33,9 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/ambd.service ${D}${systemd_unitdir}/system
 }
 
-FILES_${PN} += "${systemd_unitdir}/ambd.service"
+PRIVATE_LIBS = "libamb-plugins-common.so"
 
-INSANE_SKIP_${PN} = "dev-deps"
+FILES_${PN} += "\
+    ${systemd_unitdir}/ambd.service \
+    ${libdir}/libamb-plugins-common.so \
+"

--- a/meta-genivi-dev/meta-genivi-dev/recipes-navigation/positioning/positioning_git.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-navigation/positioning/positioning_git.bb
@@ -7,7 +7,7 @@
 # Author: Marco Residori
 #
 # Copyright (C) 2013, XS Embedded GmbH
-# 
+#
 # License:
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with
@@ -17,10 +17,10 @@
 ###########################################################################
 
 #
-# Description: This is a Yocto recipe of the 4 proofs of concept contained 
-#              in the positioning repository. 
-#              Each PoC has its own sub-package. In this way it is possible to 
-#              install only the PoC(s) that are of interest        
+# Description: This is a Yocto recipe of the 4 proofs of concept contained
+#              in the positioning repository.
+#              Each PoC has its own sub-package. In this way it is possible to
+#              install only the PoC(s) that are of interest
 #
 # Status: Work in Progress
 #
@@ -42,7 +42,7 @@ S = "${WORKDIR}/git"
 
 DEPENDS = "dbus dbus-c++ dbus-c++-native dlt-daemon gpsd libxslt-native"
 
-inherit cmake pkgconfig 
+inherit cmake pkgconfig
 
 PACKAGES =+ "${PN}-gnss ${PN}-gnss-test ${PN}-sns ${PN}-sns-test ${PN}-repl ${PN}-repl-test ${PN}-enhpos ${PN}-enhpos-test "
 
@@ -61,31 +61,29 @@ DEPENDS_${PN}-enhpos = "${PN}-gnss ${PN}-sns"
 RDEPENDS_${PN}-enhpos-test = "${PN}-enhpos"
 DEPENDS_${PN}-enhpos-test = "${PN}-enhpos"
 
-do_configure() {
-    cd ${S} && cmake -DWITH_DLT=OFF -DWITH_GPSD=OFF -DWITH_REPLAYER=ON -DWITH_TESTS=ON -DWITH_IPHONE=OFF .
-}
-
-do_compile() {
-    cd ${S} && make
-}
+EXTRA_OECMAKE = "-DWITH_DLT=OFF -DWITH_GPSD=OFF -DWITH_REPLAYER=ON -DWITH_TESTS=ON -DWITH_IPHONE=OFF"
 
 do_install() {
     install -d ${D}/${bindir}
     install -d ${D}/${libdir}
     install -d ${D}${includedir}/${PN}
     install -d ${D}${datadir}/${PN}
-    install -m 755 ${S}/log-replayer/src/log-replayer ${D}/${bindir}
-    install -m 755 ${S}/log-replayer/test/test-log-replayer ${D}/${bindir}
-    install -m 644 ${S}/log-replayer/logs/*.log ${D}${datadir}/${PN}
-    install -m 755 ${S}/gnss-service/src/*.so ${D}/${libdir}
-    install -m 755 ${S}/gnss-service/test/gnss-service-client ${D}/${bindir}
-    install -m 755 ${S}/gnss-service/test/compliance-test/gnss-service-compliance-test ${D}/${bindir}
-    install -m 755 ${S}/sensors-service/src/*.so ${D}/${libdir}
-    install -m 755 ${S}/sensors-service/test/sensors-service-client ${D}/${bindir}
-    install -m 755 ${S}/enhanced-position-service/*/src/enhanced-position-service ${D}/${bindir}
-    install -m 755 ${S}/enhanced-position-service/*/test/enhanced-position-client ${D}/${bindir}
+
+    install -m 755 ${B}/log-replayer/src/log-replayer ${D}/${bindir}
+    install -m 755 ${B}/log-replayer/test/test-log-replayer ${D}/${bindir}
+    install -m 644 ${B}/log-replayer/logs/*.log ${D}${datadir}/${PN}
+
+    install -m 755 ${B}/gnss-service/src/*.so ${D}/${libdir}
+    install -m 755 ${B}/gnss-service/test/gnss-service-client ${D}/${bindir}
+    install -m 755 ${B}/gnss-service/test/compliance-test/gnss-service-compliance-test ${D}/${bindir}
+
+    install -m 755 ${B}/sensors-service/src/*.so ${D}/${libdir}
+    install -m 755 ${B}/sensors-service/test/sensors-service-client ${D}/${bindir}
+
+    install -m 755 ${B}/enhanced-position-service/*/src/enhanced-position-service ${D}/${bindir}
+    install -m 755 ${B}/enhanced-position-service/*/test/enhanced-position-client ${D}/${bindir}
     install -m 755 ${S}/enhanced-position-service/*/api/*.xml ${D}${datadir}/${PN}
-    install -m 755 ${S}/enhanced-position-service/dbus/api/*.h ${D}${includedir}/${PN}
+    install -m 755 ${B}/enhanced-position-service/dbus/api/*.h ${D}${includedir}/${PN}
 }
 
 FILES_${PN}-gnss = "${libdir}/libgnss-service*.so "
@@ -105,7 +103,6 @@ FILES_${PN}-enhpos-test = "${bindir}/enhanced-position-client \
 
 BBCLASSEXTEND = "native"
 
-#TODO: fix this
-do_package_qa() {
-  echo "workaround to avoid problem with RPATH"
-}
+INSANE_SKIP_${PN}-gnss-test += "rpaths"
+INSANE_SKIP_${PN}-sns-test += "rpaths"
+INSANE_SKIP_${PN}-enhpos += "rpaths"

--- a/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/udisks2-disk-manager.sh
+++ b/meta-genivi-dev/meta-openembedded/meta-oe/recipes-support/udisks2/files/udisks2-disk-manager.sh
@@ -6,7 +6,7 @@ pathtoname() {
     udevadm info -p /sys/"$1" | awk -v FS== '/DEVNAME/ {print $2}'
 }
 
-stdbuf -oL -- udevadm monitor --udev -s block | while read -r -- _ _ event devpath _; do
+udevadm monitor --udev -s block | while read -r -- _ _ event devpath _; do
         if [ "$event" = add ]; then
             devname=$(pathtoname "$devpath")
             udisksctl mount --block-device "$devname" --no-user-interaction


### PR DESCRIPTION
Got rid of all "sneaky" dependencies on -dev packages polluting our target image.

Also added a test (TDD :)) to make sure that this does not sneak back in.

The last commit does not really have to do anything with GDP-787, but is more of a clean-up task which I did while I investigated all suspects.