### PR TITLE
rocko: Update Renesas R-Car Gen 3 to Yocto BSP v3.9.0

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -40,7 +40,7 @@ fi
 AGENT_STANDARD_DL_DIR="/var/cache/yocto/downloads"
 AGENT_STANDARD_SSTATE_DIR="/var/cache/yocto/sstate"
 AGENT_STANDARD_SGX_LOCATION="/var/go/sgx_bin"
-AGENT_STANDARD_SGX_GEN3_LOCATION="/var/go/rcar-gen3/gfx-mmp_ybsp-370_20180423"
+AGENT_STANDARD_SGX_GEN3_LOCATION="/var/go/rcar-gen3/gfx-mmp_ybsp-390_20180627"
 
 # ---- Helper functions ----
 


### PR DESCRIPTION
Update the Renesas R-Car Gen 3 board support to use Yocto BSP v3.9.0 (GDP-800).

Successfully sanity tested on the R-Car M3 Starter Kit.