### PR TITLE
Do not merge (WIP): Add compilers, and dependencies for VCIVING

### DIFF
--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -46,7 +46,7 @@ CONF_VERSION = "1"
 # Support OE QA test suite export with bitbake -c testexport <image name>
 INHERIT += "testexport"
 TEST_EXPORT_ONLY = "1"
-TEST_SUITES = "ping ssh scp date dmesg connman systemd gdp devpackages"
+TEST_SUITES = "ping ssh scp date dmesg connman systemd gdp"
 
 # This will be assigned to IMAGE_FSTYPE later. This default value is used if
 # the type is not defined in machine-specific templates. (At least one value

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -19,4 +19,6 @@ IMAGE_INSTALL_append = " \
     packagegroup-gdp-vsi \
     packagegroup-gdp-sdl \
     packagegroup-gdp-cdl \
-"
+    packagegroup-core-buildessential \
+    packagegroup-gdp-vciving \
+    "

--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-vciving.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-vciving.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "GENIVI Browser Proof-of-Concept (PoC) package group"
+DESCRIPTION = "VCIVING project and prerequisites, including -dev packages for on-target installations"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${IVI_COREBASE}/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
@@ -8,24 +8,18 @@ LIC_FILES_CHKSUM[vardepsexclude] += "IVI_COREBASE"
 inherit packagegroup
 
 PACKAGES = "\
-    packagegroup-gdp-browser \
+    packagegroup-gdp-vciving \
     "
 
 ALLOW_EMPTY_${PN} = "1"
 
 RDEPENDS_${PN} += "\
-    genivi-browser-test-hmi-precompiled \
-    chromium-lge \
-    avahi-daemon \
-    cannelloni \
-    cmake \
-    connman-client \
-    git \
-    openssh-sftp-server \
-    python-dev \
+    alsa-dev \
+    espeak \
+    ffmpeg-dev \
+    flac \
+    gstreamer1.0-libav \
+    portaudio-v19-dev \
     python3-dev \
-    python-pip \
     python3-pip \
-    udisks2 \
-    udisks2-disk-manager \
     "


### PR DESCRIPTION
For a development version of the image with on-target compilers
(and some other useful tools) + various -dev packages needed for
the VCIVING dependencies.

Also -dev packages for python2/3 and perl, and pip for easy installation
of python dependencies on target.

(WIP)