### PR TITLE
bblayers.inc : Update LCONF_VERSION to 7

### DIFF
--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -1,6 +1,6 @@
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
-LCONF_VERSION = "6"
+LCONF_VERSION = "7"
 
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""

--- a/gdp-src-build/conf/templates/local.inc
+++ b/gdp-src-build/conf/templates/local.inc
@@ -13,6 +13,16 @@ LICENSE_FLAGS_WHITELIST  += "commercial"
 PREFERRED_VERSION_erlang-native = "18.2.3"
 PREFERRED_VERSION_erlang = "18.2.3"
 
+# Blacklist for compilation hardening flags.
+# The poky-ivi-systemd distro file in meta-ivi includes security_flags.inc
+# Some packages apparently fail if (some) flags are applied, so they are
+# updated here to not apply them, or apply them partially.  This lists the
+# packages that are in GDP only, not in meta-ivi.
+SECURITY_CFLAGS_pn-dbus-c++ = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-python-uinput = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-python-storm = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-iotivity = ""
+
 # Disk Space Monitoring during the build
 #
 # Monitor the disk space during the build. If there is less that 1GB of space or less

--- a/meta-genivi-dev/meta-genivi-dev/recipes-cdl/cdl-concept-demo/cdl-concept-demo.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-cdl/cdl-concept-demo/cdl-concept-demo.bb
@@ -7,7 +7,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 SRC_URI = "git://github.com/GENIVI/car-data-logger.git;protocol=https"
 SRCREV  = "c63adbb4809319a53a934dbf9f344f75c738d570"
 
-DEPENDS = "qtbase qtdeclarative vsomeip common-api-c++-someip dbus dlt-daemon common-api-c++-dbus common-api-c++"
+DEPENDS = "common-api-c++ common-api-c++-dbus common-api-c++-someip dbus dlt-daemon qtbase qtdeclarative vsomeip"
+RDEPENDS_${PN} = "bash"
 
 S = "${WORKDIR}/git"
 

--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/genivi-browser-test-hmi-precompiled/genivi-browser-test-hmi-precompiled.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/genivi-browser-test-hmi-precompiled/genivi-browser-test-hmi-precompiled.bb
@@ -4,7 +4,7 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=815ca599c9df247a0c7f619bab123dad"
 PR = "r0"
 
-RDEPENDS_${PN} = "python-pyqt"
+RDEPENDS_${PN} = "bash python-pyqt"
 
 SRC_URI = "file://genivi-browser-test.tar.bz2"
 


### PR DESCRIPTION
poky is now on LAYER_CONF_VERSION=7 and for some reason the built-in automatic upgrade of LCONF_VERSION has started to fail execution inside sanity.bbclass.   Some python/parsing issue. It might have a fix already.  Anyway I can't figure it out and thought we can just as well update our conf version.

It is time to update poky (rocko maintenance branch) also anyway but that can come after this.
