### PR TITLE
Test Remove meta-gnome layer

### DIFF
--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -13,7 +13,6 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-ivi/meta-ivi-bsp \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
-  ${TOPDIR}/../meta-openembedded/meta-gnome \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-gplv2 \


### PR DESCRIPTION
Looks like chromium depended on gnome keyring but after the switch to
meta-lgsvl-browser layer, I can't find this, or any dependency any longer.  
Let's see if it builds without meta-gnome.
