### PR TITLE
init: add Renesas R-Car Gen 3 Salvator-X(S) board support

### DIFF
--- a/gdp-src-build/conf/templates/r-car-h3-salvator-x.bblayers.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-salvator-x.bblayers.conf
@@ -1,0 +1,7 @@
+include templates/bblayers.inc
+
+# Include bblayers used for all Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.bblayers.inc
+
+# Renesas R-Car H3 Starter Kit Premium specific layer configuration
+# should be added here. None to add at this time.

--- a/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
@@ -1,0 +1,12 @@
+# Include general conf for Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.local.inc
+
+# Renesas gfx/mmp package control:
+# 1) For the Evaluation (click-through licensed) gfx/mmp packages
+#    'use_eva_pkg' must be added to DISTRO_FEATURES.
+# 2) If you are using the full version of those packages then
+#    comment out this line as it is not needed.
+DISTRO_FEATURES_append = " use_eva_pkg"
+
+# Select the H3 Salvator-X board
+MACHINE = "salvator-x"

--- a/gdp-src-build/conf/templates/r-car-m3-salvator-x.bblayers.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-salvator-x.bblayers.conf
@@ -1,0 +1,7 @@
+include templates/bblayers.inc
+
+# Include bblayers used for all Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.bblayers.inc
+
+# Renesas R-Car M3 Starter Kit Pro specific layer configuration
+# should be added here. None to add at this time.

--- a/gdp-src-build/conf/templates/r-car-m3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-salvator-x.local.conf
@@ -1,0 +1,12 @@
+# Include general conf for Renesas R-Car Gen 3 boards
+include templates/renesas-rcar-gen3.local.inc
+
+# Renesas gfx/mmp package control:
+# 1) For the Evaluation (click-through licensed) gfx/mmp packages
+#    'use_eva_pkg' must be added to DISTRO_FEATURES.
+# 2) If you are using the full version of those packages then
+#    comment out this line as it is not needed.
+DISTRO_FEATURES_append = " use_eva_pkg"
+
+# Select the M3 Salvator-X board
+MACHINE = "salvator-x"


### PR DESCRIPTION
Add missing local.conf and bblayer.conf support for Salvator-X to PR #212. Needs to be merged.
Untested. Would set WIP label but I don't seem to have the rights to set them for some reason.