### PR TITLE
ci-build: Use RM_WORK by default

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -240,7 +240,7 @@ define_with_default LAYER_ARCHIVE false
 define_with_default CREATE_RELEASE_DIR false
 define_with_default MIRROR "https://docs.projects.genivi.org/releases/yocto_mirror"
 define_with_default PREMIRROR ""  # By default none (but we have the shared DL_DIR)
-define_with_default RM_WORK false
+define_with_default RM_WORK true
 define_with_default REUSE_STANDARD_DL_DIR true
 define_with_default REUSE_STANDARD_SSTATE_DIR true
 define_with_default SGX_DRIVERS $AGENT_STANDARD_SGX_LOCATION


### PR DESCRIPTION
To save diskspace in build environment we'll make this the default. As
before, environment variables can be overridden. export RM_WORK=false
before running script if you want to keep those files.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>