### PR TITLE
cannelloni: fix license checksum

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/cannelloni.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-extended/cannelloni/cannelloni.bb
@@ -1,7 +1,7 @@
 SUMMARY = "SocketCAN over Ethernet tunnel using UDP to transfer CAN frames between two machines"
 SECTION = "console/network"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=B234EE4D69F5FCE4486A80FDAF4A4263"
+LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 PR = "r0"
 


### PR DESCRIPTION
The license file md5 checksum is specified in uppercase which can lead
to a build error when compared to a lowercase sum generated at runtime.
For example:
ERROR: cannelloni-1.0-r0 do_populate_lic: QA Issue: cannelloni: The LIC_FILES_CHKSUM does not match for file://gpl-2.0.txt;md5=B234EE4D69F5FCE4486A80FDAF4A4263
cannelloni: The new md5 checksum is b234ee4d69f5fce4486a80fdaf4a4263

To avoid such issues specify the checksum in lowercase.

The strange thing in my mind is why this has not been an error before as the checksum check in insane.bbclass appears to be case sensitive. I see the error in a build for H3 Starter Kit, but M3 Starter Kit is ok. I've posted a question about that to the YP mailing list.