### PR TITLE
[WIP] Update Renesas R-Car Salvator-X board template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ To initiate the build environment:
     source init.sh $target
 
 The current supported targets are qemux86-64, raspberrypi2, raspberrypi3,
-minnowboard, r-car-m3-starter-kit and r-car-h3-starter-kit.
-Currently this requires the use of the bash shell.
+minnowboard, r-car-m3-starter-kit, r-car-h3-starter-kit, r-car-m3-salvator-x
+and r-car-h3-salvator-x. Currently this requires the use of the bash shell.
 
 The `init.sh` script handles the the `$target` specific bitbake configuration.
 The `$target` templates can be found in gdp-src-build/templates, as well as common

--- a/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
@@ -1,9 +1,3 @@
-# Select the Salvator-X board
-MACHINE = "salvator-x"
-
-# Specify H3 variant
-SOC_FAMILY="r8a7795"
-
 # Include general conf for Renesas R-Car Gen 3 boards
 include templates/renesas-rcar-gen3.local.inc
 
@@ -14,4 +8,8 @@ include templates/renesas-rcar-gen3.local.inc
 #    comment out this line as it is not needed.
 DISTRO_FEATURES_append = " use_eva_pkg"
 
+# Select the Salvator-X board
+MACHINE = "salvator-x"
 
+# Specify H3 variant
+SOC_FAMILY = "r8a7795"

--- a/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
@@ -11,6 +11,14 @@ DISTRO_FEATURES_append = " use_eva_pkg"
 # Enable USB 3.0 (comment out line to disable)
 MACHINE_FEATURES_append = " usb3"
 
+# U-boot/IPL option for H3 (SoC: r8a7795)
+# For H3 SiP DDR 4GiB (1GiB x 4ch)
+#H3_OPTION = "0"
+# For H3 SiP DDR 8GiB (2GiB x 4ch)
+H3_OPTION = "1"
+# For H3 SiP DDR 4GiB (2GiB x 2ch)
+#H3_OPTION = "2"
+
 # Select the Salvator-X board
 MACHINE = "salvator-x"
 

--- a/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-h3-salvator-x.local.conf
@@ -8,6 +8,9 @@ include templates/renesas-rcar-gen3.local.inc
 #    comment out this line as it is not needed.
 DISTRO_FEATURES_append = " use_eva_pkg"
 
+# Enable USB 3.0 (comment out line to disable)
+MACHINE_FEATURES_append = " usb3"
+
 # Select the Salvator-X board
 MACHINE = "salvator-x"
 

--- a/gdp-src-build/conf/templates/r-car-m3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-salvator-x.local.conf
@@ -8,6 +8,9 @@ include templates/renesas-rcar-gen3.local.inc
 #    comment out this line as it is not needed.
 DISTRO_FEATURES_append = " use_eva_pkg"
 
+# Enable USB 3.0 (comment out line to disable)
+MACHINE_FEATURES_append = " usb3"
+
 # Select the Salvator-X board
 MACHINE = "salvator-x"
 

--- a/gdp-src-build/conf/templates/r-car-m3-salvator-x.local.conf
+++ b/gdp-src-build/conf/templates/r-car-m3-salvator-x.local.conf
@@ -1,9 +1,3 @@
-# Select the Salvator-X board
-MACHINE = "salvator-x"
-
-# Specify M3 variant
-SOC_FAMILY="r8a7796"
-
 # Include general conf for Renesas R-Car Gen 3 boards
 include templates/renesas-rcar-gen3.local.inc
 
@@ -14,3 +8,8 @@ include templates/renesas-rcar-gen3.local.inc
 #    comment out this line as it is not needed.
 DISTRO_FEATURES_append = " use_eva_pkg"
 
+# Select the Salvator-X board
+MACHINE = "salvator-x"
+
+# Specify M3 variant
+SOC_FAMILY = "r8a7796"

--- a/gdp-src-build/conf/templates/renesas-rcar-gen3.local.inc
+++ b/gdp-src-build/conf/templates/renesas-rcar-gen3.local.inc
@@ -154,5 +154,8 @@ DISTRO_FEATURES_append = " avb"
 # Configuration for ivi-shell and ivi-extension
 #DISTRO_FEATURES_append = " ivi-shell"
 
+# Configuration for USB 3.0
+#MACHINE_FEATURES_append = " usb3"
+
 # Add Capacity Aware migration Strategy (CAS)
 MACHINE_FEATURES_append = " cas"


### PR DESCRIPTION
- Enable USB 3.0 support in Salvator-X builds
- Reorder the lines in the local.conf templates so they follow that used in the Starter Kit templates and the sample local.confs in the Yocto BSP.
- add missing u-boot/IPL build options to H3 Salvator-X local.conf template.
- add the Salvator-X boards to the README.

Marked WIP as code is currently under testing.