### PR TITLE
gdp-new-hmi: fix SRCREV

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     file://gdp-new-hmi.service \
 "
 
-SRCREV = "95aadfb33d95e14030585c3fa2e1afb0e7b743c8"
+SRCREV = "86f5a365a0b1c4cd96a6344db7137a0440c11f7b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This commit:

    https://github.com/GENIVI/genivi-dev-platform/commit/fa227829f1696775a02396eafb73db05748b4f1f

Accidently downgraded the GDP HMI to a revision that is
broken. Fix by updating to the latest known revision.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>