### PR TITLE
genivi-dev-platform-core: Set image PV to 14 on master branch

### DIFF
--- a/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform-core.bb
+++ b/meta-genivi-dev/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform-core.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "GENIVI Development Platform core image (minimal)"
 
-PV = "13.0"
+PV = "14.0"
 
 IMAGE_FEATURES_append = " ssh-server-openssh tools-debug"
 


### PR DESCRIPTION
Just a minor PR to bump the PV set in the image recipe - to for mirzak to comment.  
Is this PV setting reused for other images that include core, and does it serve some useful purpose or not much...  Read commit comment for rationale also.  We could have a chat in person, if it's easier.
